### PR TITLE
add support for non linux UNIX OS (tested on AIX)

### DIFF
--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -320,7 +320,13 @@ Will use HTML5 for this SASsession.""")
          pout = os.pipe()
          perr = os.pipe() 
       
-         pidpty = os.forkpty()
+         
+         try:
+            pidpty = os.forkpty()
+         except:
+            import pty
+            pidpty = pty.fork()
+         
          if pidpty[0]:
             # we are the parent
             self.pid = pidpty[0]

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -224,7 +224,12 @@ Will use HTML5 for this SASsession.""")
       pout = os.pipe()
       perr = os.pipe() 
       
-      pidpty = os.forkpty()
+      try:
+         pidpty = os.forkpty()
+      except:
+         import pty
+         pidpty = pty.fork()
+         
       if pidpty[0]:
          # we are the parent
 


### PR DESCRIPTION
Added support for UNIX operating systems not having pty.h header in gnulibs, and that's why not being able to handle os.forkpty()

Python itself can handle this via pty module where such exception is done. Just have to use it in 2 of sasPY modules

Tested on AIX. Possible other OS affected Minix , HP-UX, IRIX, Solaris, BeOS

 Issue #43 
