### PR TITLE
Add options for alternate ssh port and reverse tunnel

### DIFF
--- a/saspy/doc/source/install.rst
+++ b/saspy/doc/source/install.rst
@@ -225,6 +225,26 @@ host -
 .. note:: The ``'ssh'`` key is the trigger to use the STDIO over SSH connection
           method.
 
+To accomodate alternative SSH configurations, you may also provide one or both of the 
+following optional keys:
+
+port -
+    (Optional: integer) The ssh port of the remote machine (equivalent to invoking ssh with the ``-p`` option)
+
+tunnel -
+    (Optional: integer) Certain methods of saspy require opening a local port and accepting data 
+    streamed from the SAS instance. If the remote SAS server would not be able to reach ports on your client machine 
+    due to a firewall or other security configuration, you may pass a local port number to be reverse tunneled 
+    (using the ``-R`` ssh option) so that the remote SAS server can connect using this port.
+
+.. code-block:: ipython3
+
+    ssh      = {'saspath' : '/opt/sasinside/SASHome/SASFoundation/9.4/bin/sas_u8',
+                'ssh'     : '/usr/bin/ssh',
+                'host'    : 'remote.linux.host',
+                'port'    : 9922,
+                'tunnel'  : 9911
+               }
 
 
 IOM

--- a/saspy/sascfg.py
+++ b/saspy/sascfg.py
@@ -74,6 +74,10 @@ SAS_output_options = {'output' : 'html5'}
 # 'ssh'     - [REQUIRED] the ssh command to run
 # 'host'    - [REQUIRED] the host to connect to
 #
+# Additional valid keys for ssh:
+# 'port'    - [integer] the remote ssh port
+# 'tunnel'  - [integer] local port to open via reverse tunnel, if remote host cannot otherwise reach this client
+#
 default  = {'saspath'  : '/opt/sasinside/SASHome/SASFoundation/9.4/bin/sas_u8'
             }
 

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -978,8 +978,10 @@ Will use HTML5 for this SASsession.""")
 
       try:
          sock = socks.socket()
-         sock.setsockopt(socks.SOL_SOCKET, socks.SO_REUSEADDR, 1)
-         sock.bind(("localhost",port))
+         if self.sascfg.tunnel:
+            sock.bind(('localhost', port))
+         else:
+            sock.bind(('', port))
          port = sock.getsockname()[1]
       except OSError:
          print('Error try to open a socket in the sasdata2dataframe method. Call failed.')

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -50,8 +50,8 @@ class SASconfigSTDIO:
       self.saspath  = cfg.get('saspath', '')
       self.options  = cfg.get('options', [])
       self.ssh      = cfg.get('ssh', '')
-      self.tunnel   = cfg.get('tunnel', '')
-      self.port     = cfg.get('port', '')
+      self.tunnel   = cfg.get('tunnel', None)
+      self.port     = cfg.get('port', None)
       self.host     = cfg.get('host', '')
       self.encoding = cfg.get('encoding', '')
       self.metapw   = cfg.get('metapw', '')
@@ -98,6 +98,20 @@ class SASconfigSTDIO:
          else:
             self.ssh = inssh
 
+      intunnel = kwargs.get('tunnel', None)
+      if intunnel is not None:
+         if lock:
+            print("Parameter 'tunnel' passed to SAS_session was ignored due to configuration restriction.")
+         else:
+            self.tunnel = intunnel
+      
+      inport = kwargs.get('port', None)
+      if inport is not None:
+         if lock:
+            print("Parameter 'port' passed to SAS_session was ignored due to configuration restriction.")
+         else:
+            self.port = inport
+      
       inhost = kwargs.get('host', '')
       if len(inhost) > 0:
          if lock and len(self.host):

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -50,6 +50,8 @@ class SASconfigSTDIO:
       self.saspath  = cfg.get('saspath', '')
       self.options  = cfg.get('options', [])
       self.ssh      = cfg.get('ssh', '')
+      self.tunnel   = cfg.get('tunnel', '')
+      self.port     = cfg.get('port', '')
       self.host     = cfg.get('host', '')
       self.encoding = cfg.get('encoding', '')
       self.metapw   = cfg.get('metapw', '')
@@ -175,46 +177,59 @@ class SASsessionSTDIO():
           self._log_cnt += 1
        return '%08d' % self._log_cnt
 
-   def _startsas(self):
-      #import pdb;pdb.set_trace()
-      if self.pid:
-         return self.pid
-
-      if self.sascfg.ssh:
-         pgm    = self.sascfg.ssh
+   def _buildcommand(self, sascfg):
+      if sascfg.ssh:
+         pgm    = sascfg.ssh
          parms  = [pgm]
-         parms += ["-t", self.sascfg.host, self.sascfg.saspath]
+         parms += ["-t", sascfg.host]
 
-         if self.sascfg.output.lower() == 'html':
+         if sascfg.port:
+            parms += ["-p", str(sascfg.port)]
+         
+         if sascfg.tunnel:
+            parms += ["-R", '%d:localhost:%d' % (sascfg.tunnel,sascfg.tunnel)]
+
+         parms += [sascfg.saspath]
+
+         if sascfg.output.lower() == 'html':
             print("""HTML4 is only valid in 'local' mode (SAS_output_options in sascfg.py).
 Please see SAS_config_names templates 'default' (STDIO) or 'winlocal' (IOM) in the default sascfg.py.
 Will use HTML5 for this SASsession.""")
-            self.sascfg.output = 'html5'
+            sascfg.output = 'html5'
       else:
-         pgm    = self.sascfg.saspath
+         pgm    = sascfg.saspath
          parms  = [pgm]
 
       # temporary hack for testing grid w/ sasgsub and iomc ...
-      if self.sascfg.iomc:
-         pgm    = self.sascfg.iomc
+      if sascfg.iomc:
+         pgm    = sascfg.iomc
          parms  = [pgm]
          parms += ["user", "sas", "pw", "sas"]
          parms += ['']
-      elif self.sascfg.metapw:
-         pgm    = self.sascfg.ssh
+      elif sascfg.metapw:
+         pgm    = sascfg.ssh
          parms  = [pgm]
-         parms += ["-t", "-i", "/u/sastpw/idrsacnn", self.sascfg.host]
-         parms += self.sascfg.options
-         #parms += ['"'+self.sascfg.saspath+' -nodms -stdio -terminal -nosyntaxcheck -pagesize MAX"']
+         parms += ["-t", "-i", "/u/sastpw/idrsacnn", sascfg.host]
+         parms += sascfg.options
+         #parms += ['"'+sascfg.saspath+' -nodms -stdio -terminal -nosyntaxcheck -pagesize MAX"']
          parms += ['']
       else:
-         parms += self.sascfg.options
+         parms += sascfg.options
          parms += ["-nodms"]
          parms += ["-stdio"]
          parms += ["-terminal"]
          parms += ["-nosyntaxcheck"]
          parms += ["-pagesize", "MAX"]
          parms += ['']
+
+      return [pgm, parms]
+
+   def _startsas(self):
+      #import pdb;pdb.set_trace()
+      if self.pid:
+         return self.pid
+
+      pgm, parms = self._buildcommand(self.sascfg)
 
       s = ''
       for i in range(len(parms)):
@@ -888,6 +903,11 @@ Will use HTML5 for this SASsession.""")
       port    - port to use for socket. Defaults to 0 which uses a random available ephemeral port
       '''
       port =  kwargs.get('port', 0)
+
+      if port==0 and self.sascfg.tunnel:
+         # we are using a tunnel; default to that port
+         port = self.sascfg.tunnel
+
       #import pandas as pd
       import socket as socks
       datar = ""
@@ -944,14 +964,18 @@ Will use HTML5 for this SASsession.""")
 
       try:
          sock = socks.socket()
-         sock.bind(("",port))
+         sock.setsockopt(socks.SOL_SOCKET, socks.SO_REUSEADDR, 1)
+         sock.bind(("localhost",port))
          port = sock.getsockname()[1]
       except OSError:
          print('Error try to open a socket in the sasdata2dataframe method. Call failed.')
          return None
 
       if self.sascfg.ssh:
-         host = socks.gethostname()
+         if not self.sascfg.tunnel:
+            host = socks.gethostname()
+         else:
+            host = 'localhost'
       else:
          host = ''
 

--- a/saspy/tests/test_sasconfig.py
+++ b/saspy/tests/test_sasconfig.py
@@ -27,6 +27,42 @@ class TestSASconfigObject(unittest.TestCase):
             sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='default')
 
             self.assertEqual(sascfg.saspath, bare_config['saspath'], msg=u'saspath config was not used')
+    
+    def test_SASconfig_arguments(self):
+        # test overrides with and without lock_down set
+        locked = dict(lock_down=True)
+        unlocked = dict(lock_down=False)
+
+        unlocked_config = dict(
+            saspath= '/some/fake/path'
+        )
+
+        with patch.multiple('saspy.sasbase.SAScfg', custom=unlocked_config, SAS_config_options=unlocked, create=True):
+            overrides = dict(saspath= '/overridden/sas/path')
+            sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='custom', **overrides)
+
+            self.assertEqual(
+                sascfg.saspath, 
+                overrides['saspath'], 
+                msg=u'override of config was disallowed with lock_down=False'
+            )
+
+        #test with lock_down enabled, should disallow override
+        locked_config = dict(
+            saspath= '/another/fake/path'
+        )
+
+        with patch.multiple('saspy.sasbase.SAScfg', custom=locked_config, SAS_config_options=locked, create=True):
+            # prevent print() from logging warning in test console
+            with patch('sys.stdout') as PrintMock:
+                overrides = dict(saspath= '/another/overridden/sas/path')
+                sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='custom', **overrides)
+
+                self.assertEqual(
+                    sascfg.saspath, 
+                    locked_config['saspath'], 
+                    msg=u'override of config was allowed with lock_down=True'
+                )
 
     def test_ssh_config(self):
         # simple ssh mock configuration
@@ -63,4 +99,28 @@ class TestSASconfigObject(unittest.TestCase):
             self.assertIn('-R 9911:localhost:9911', joined, msg=u'ssh tunnel config was not used')
             self.assertIn('-p 9922', joined, msg=u'ssh port config was not used')
 
+        # test that direct arguments are permitted 
+        with patch.multiple(
+            'saspy.sasbase.SAScfg', ssh=simple_ssh, SAS_config_names=['ssh'], create=True,
+            SAS_config_options=dict(lock_down=False)
+        ):
+            sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='ssh', port=8888, tunnel=9999)
+            pgm, params = saspy.sasiostdio.SASsessionSTDIO._buildcommand({}, sascfg)
+            joined = ' '.join(params)
 
+            self.assertIn('-R 9999:localhost:9999', joined, msg=u'ssh tunnel config argument was not used')
+            self.assertIn('-p 8888', joined, msg=u'ssh port config argument was not used')
+
+        # test that direct argument do not apply in lock_down mode
+        with patch.multiple(
+            'saspy.sasbase.SAScfg', ssh=simple_ssh, SAS_config_names=['ssh'], create=True,
+            SAS_config_options=dict(lock_down=True)
+        ):
+            # prevent print() from logging warning in test console
+            with patch('sys.stdout') as PrintMock:
+                sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='ssh', port=8888, tunnel=9999)
+                pgm, params = saspy.sasiostdio.SASsessionSTDIO._buildcommand({}, sascfg)
+                joined = ' '.join(params)
+
+                self.assertNotIn('-R', params, msg=u'ssh tunnel argument was allowed with lock_down=True')
+                self.assertNotIn('-p', params, msg=u'ssh alternate port argument was allowed with lock_down=True')

--- a/saspy/tests/test_sasconfig.py
+++ b/saspy/tests/test_sasconfig.py
@@ -1,33 +1,66 @@
 import unittest
+from unittest.mock import patch
 import saspy
-
 
 class TestSASconfigObject(unittest.TestCase):
     @classmethod    
     def setUpClass(cls):
-        cls.sas = saspy.SASsession() #cfgname='default')
-        #cls.assertIsInstance(cls.sas, saspy.SASsession, msg="sas = saspy.SASsession(...) failed")
+        pass
 
     @classmethod
     def tearDownClass(cls):
-        if cls.sas:
-           cls.sas._endsas()
-
-
-    def __del__(self, *args):
-        if self.sas:
-           self.sas._endsas()
+        pass
 
     def setUp(self):
-        #self.sas = saspy.SASsession()
         pass
 
     def tearDown(self):
-        #if self.sas:
-        #   self.sas._endsas()
         pass
 
     def test_SASconfig(self):
-        pass
+        # basic mock configuration
+        bare_config = dict(
+            saspath= '/fake/sas/path'
+        )
+
+        with patch.multiple('saspy.sasbase.SAScfg', default=bare_config):
+            sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='default')
+
+            self.assertEqual(sascfg.saspath, bare_config['saspath'], msg=u'saspath config was not used')
+
+    def test_ssh_config(self):
+        # simple ssh mock configuration
+        simple_ssh =dict(
+            saspath= '/opt/sasinside/SASHome/SASFoundation/9.4/bin/sas_u8',
+            ssh= '/bin/ssh',
+            host= 'hostname',
+        )
+
+        with patch.multiple('saspy.sasbase.SAScfg', ssh=simple_ssh, SAS_config_names=['ssh'], create=True):
+            sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='ssh')
+            pgm, params = saspy.sasiostdio.SASsessionSTDIO._buildcommand({}, sascfg)
+
+            self.assertEqual(pgm, simple_ssh['ssh'], msg=u'ssh config was not used')
+            self.assertNotIn('-R', params, msg=u'ssh tunnel was used though not configured')
+            self.assertNotIn('-p', params, msg=u'ssh alternate port was used though not configured')
+
+        # mock ssh config with additional options
+        ssh_config =dict(
+            saspath= '/opt/sasinside/SASHome/SASFoundation/9.4/bin/sas_u8',
+            ssh= '/bin/ssh-alt',
+            host= 'hostname',
+            port= 9922,
+            tunnel= 9911,
+            encoding= 'latin1'
+        )
+
+        with patch.multiple('saspy.sasbase.SAScfg', ssh=ssh_config, SAS_config_names=['ssh'], create=True):
+            sascfg = saspy.sasiostdio.SASconfigSTDIO(sascfgname='ssh')
+            pgm, params = saspy.sasiostdio.SASsessionSTDIO._buildcommand({}, sascfg)
+            joined = ' '.join(params)
+
+            self.assertEqual(pgm, ssh_config['ssh'], msg=u'ssh config was not used')
+            self.assertIn('-R 9911:localhost:9911', joined, msg=u'ssh tunnel config was not used')
+            self.assertIn('-p 9922', joined, msg=u'ssh port config was not used')
 
 


### PR DESCRIPTION
I've found that using the SSH connection option is limited in my use cases when connecting to a server over VPN, or in any situation where (A) I need to use an alternate SSH port, or (B) my local machine cannot be accessed directly by the remote machine.

I added a couple of options to the ssh configuration to help with both of these cases:

 - **port** - an alternative remote ssh port
 - **tunnel** - this solves a problem that was breaking basic pandas <-> SAS functionality when a firewall or security configuration blocks the remote server from accessing arbitrary ports on the local machine; `sasdata2dataframe` needs to open a local port for streaming data in from the SAS session, but the remote machine could not reach it. If you pass a `tunnel` port number, it will now establish a reverse tunnel on that port, using it to transmit the data by default. 

I've written configuration tests that verify these options are being processed correctly without needing to have a live connection that supports them. Note that checking the commands carefully in tests required moving the construction of execv parameters into a separate method (`_buildcommand`). Thoughts welcome!