### PR TITLE
Allow to share saspy session with cell magics

### DIFF
--- a/saspy/doc/source/overview.rst
+++ b/saspy/doc/source/overview.rst
@@ -62,6 +62,25 @@ results. ::
     set sashelp.cars;
   run;
 
+If you are also invoking ``saspy`` methods directly in other cells within the 
+same notebook, you may indicate that a ``%%SAS`` cell should share the same 
+SAS session by passing your existing session as a parameter.
+
+In a prior cell in the notebook: ::
+
+  import saspy
+  my_session = saspy.SASsession()
+  
+  # sending a dataset to SAS as 'mydata'
+  mydata = sas.df2sd(some_pandas_dataframe, 'mydata')
+
+Then later, invoke a SAS cell and pass your existing session so that the remote data 
+set is accessible: ::
+
+  %%SAS my_session
+  proc print data=work.mydata;
+  run;
+
 The ``%%IML`` magic enables you to submit the contents of a cell to your SAS
 session for processing with PROC IML. The cell magic executes the contents
 of the cell and returns any results. The PROC IML statement and the trailing

--- a/saspy/sas_magic.py
+++ b/saspy/sas_magic.py
@@ -18,6 +18,7 @@ from IPython.display import HTML
 import IPython.core.magic as ipym
 import re
 from saspy.SASLogLexer import SASLogStyle, SASLogLexer
+from saspy import SASsession
 from pygments.formatters import HtmlFormatter
 from pygments import highlight
 
@@ -31,10 +32,9 @@ class SASMagic(ipym.Magics):
 
     def __init__(self, shell):
         super(SASMagic, self).__init__(shell)
-        import saspy as saspy
         self.lst_len = -99  # initialize the length to a negative number to trigger function
-        self.mva = saspy.SASsession(kernel=None)
-        if self.lst_len < 0:
+        self.mva = None
+        if self.lst_len < 0 and isinstance(self.mva, SASsession) :
             self._get_lst_len()
 
     @ipym.cell_magic
@@ -54,22 +54,40 @@ class SASMagic(ipym.Magics):
             run;
         """
         
+        mva = self.mva
+        if len(line) and line in self.shell.user_ns:  # session supplied
+            _mva = self.shell.user_ns[line]
+            if isinstance(_mva, SASsession):
+                mva = _mva
+            else:
+                return 'Invalid SAS Session object supplied'
+        elif len(line) and not line in self.shell.user_ns:  # string supplied but not a session
+            return 'Invalid SAS Session object supplied'
+        else:  # no string should default to last session called
+            try:
+                if mva is None:
+                    mva = SASsession()
+                    self.mva = mva  # save the session for reuse
+                else:
+                    mva = self.mva
+            except:
+                return "this shouldn't happen"
         saveOpts="proc optsave out=__jupyterSASKernel__; run;"
         restoreOpts="proc optload data=__jupyterSASKernel__; run;"
         if len(line)>0:  # Save current SAS Options
-            self.mva.submit(saveOpts)
+            mva.submit(saveOpts)
 
         if line.lower()=='smalllog':
-            self.mva.submit("options nosource nonotes;")
+            mva.submit("options nosource nonotes;")
 
         elif line is not None and line.startswith('option'):
-            self.mva.submit(line + ';')
+            mva.submit(line + ';')
 
-        res = self.mva.submit(cell)
+        res = mva.submit(cell)
         dis = self._which_display(res['LOG'], res['LST'])
 
         if len(line)>0:  # Restore SAS options 
-            self.mva.submit(restoreOpts)
+            mva.submit(restoreOpts)
 
         return dis
 

--- a/saspy/sas_magic.py
+++ b/saspy/sas_magic.py
@@ -63,7 +63,7 @@ class SASMagic(ipym.Magics):
                 return 'Invalid SAS Session object supplied'
         elif len(line) and not line in self.shell.user_ns:  # string supplied but not a session
             return 'Invalid SAS Session object supplied'
-        else:  # no string should default to last session called
+        else:  # no string should default to unnamed session
             try:
                 if mva is None:
                     mva = SASsession()

--- a/saspy/tests/test_sasmagic.py
+++ b/saspy/tests/test_sasmagic.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+from saspy.sas_magic import SASMagic
+from saspy import SASsession
+
+class TestSASMagic(unittest.TestCase):
+    @classmethod    
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_sas_magic_existing_session(self):
+        # mocked with existing session (mva)
+        # shape: {shell: {user_ns: []}, mva: {submit: func()}}
+        mock = MagicMock()
+        mva = MagicMock()
+        shell = MagicMock()
+        submit = MagicMock(return_value=dict(LOG='log', LST='list'))
+
+        type(mva).submit = PropertyMock(return_value=submit)
+        type(mock).mva = PropertyMock(return_value=mva)
+        type(shell).user_ns = PropertyMock(return_value=[])
+        type(mock).shell = PropertyMock(return_value=shell)
+
+        test_cell = 'proc print data=work.test; run;'
+        SASMagic.SAS(mock, '', test_cell)
+
+        self.assertEqual(submit.call_count, 1, msg=u'sas code was not submitted')
+        submit.assert_called_with(test_cell)
+
+    def test_sas_magic_supplied_session(self):
+        # mocked with session option existing in namespace
+        # shape: {shell: {user_ns: [existing_session]}, mva: None}
+        mock = MagicMock()
+        shell = MagicMock()
+
+        mva = MagicMock(spec=SASsession)
+        submit = MagicMock(return_value=dict(LOG='log', LST='list'))
+        type(mva).submit = PropertyMock(return_value=submit)
+
+        # existing_session (mva) is in user namespace
+        user_ns = dict(existing_session=mva)
+        type(shell).user_ns = PropertyMock(return_value=user_ns)
+        type(mock).shell = PropertyMock(return_value=shell)
+        # no preset mva 
+        type(mock).mva = PropertyMock(return_value=None)
+
+        test_cell = 'proc datasets; run;'
+        SASMagic.SAS(mock, 'existing_session', test_cell)
+
+        self.assertEqual(submit.called, True, msg=u'sas code was not submitted')
+        submit.assert_any_call(test_cell)
+
+        # now test with non-existing session; expect error
+        submit.reset_mock()
+        output = SASMagic.SAS(mock, 'bad_session', test_cell)
+        self.assertEqual(submit.called, False)
+        self.assertIn('Invalid SAS Session', output)
+


### PR DESCRIPTION
This PR addresses https://github.com/sassoftware/saspy/issues/26, with thanks to @jld23 for assistance. I've updated the docs and added tests that spy on the `%%SAS` invocation to ensure the correct session object is used.