### PR TITLE
remove pre-commit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='saspy',
       packages = ['saspy'],
       cmdclass = {},
       package_data = {'': ['*.js', '*.md', '*.yaml', '*.css', '*.rst'], 'saspy': ['*.sas', 'java/*.*', 'java/pyiom/*.*']},
-      install_requires = ['pygments', 'ipython>=4.0.0', 'pre-commit'],
+      install_requires = ['pygments', 'ipython>=4.0.0'],
       classifiers = [
         'Programming Language :: Python :: 3',
         "Programming Language :: Python :: 3.4",


### PR DESCRIPTION
Pre-commit is a dev tool used to run quality checks before commiting.
It should not be in the main dependencies of the application.

Since there is no pre-commit config file, (.pre-commit-config.yaml)
I've taken the liberty to remove it altogether.

Fixes #74