### PR TITLE
add ~ modifier to keep outer quotes

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -616,7 +616,7 @@ class SASsession():
             return log
 
     def df2sd(self, df: 'pd.DataFrame', table: str = '_df', libref: str = '',
-              results: str = '') -> 'SASdata':
+              results: str = '', keep_outer_quotes: bool=False) -> 'SASdata':
         """
         This is an alias for 'dataframe2sasdata'. Why type all that?
 
@@ -626,10 +626,10 @@ class SASsession():
         :param results: format of results, SASsession.results is default, PANDAS, HTML or TEXT are the alternatives
         :return: SASdata object
         """
-        return self.dataframe2sasdata(df, table, libref, results)
+        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes)
 
     def dataframe2sasdata(self, df: 'pd.DataFrame', table: str = '_df', libref: str = '',
-                          results: str = '') -> 'SASdata':
+                          results: str = '', keep_outer_quotes: bool=False) -> 'SASdata':
         """
         This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
 
@@ -645,7 +645,7 @@ class SASsession():
             print("too complicated to show the code, read the source :), sorry.")
             return None
         else:
-            self._io.dataframe2sasdata(df, table, libref)
+            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes)
 
         if self.exist(table, libref):
             return SASdata(self, libref, table, results)

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1079,7 +1079,7 @@ Will use HTML5 for this SASsession.""")
          ll = self.submit(code, "text")
          return ll['LOG']
 
-   def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', libref: str =""):
+   def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', libref: str ="", keep_outer_quotes: bool=False):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1100,6 +1100,8 @@ Will use HTML5 for this SASsession.""")
             if col_l == 0:
                col_l = 8
             length += " '"+df.columns[name]+"'n $"+str(col_l)
+            if keep_outer_quotes:
+               input  += "~ "
             dts.append('C')
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -882,7 +882,7 @@ Will use HTML5 for this SASsession.""")
          ll = self.submit(code, "text")
          return ll['LOG']
 
-   def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', libref: str =""):
+   def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', libref: str ="", keep_outer_quotes: bool=False):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -903,6 +903,8 @@ Will use HTML5 for this SASsession.""")
             if col_l == 0:
                col_l = 8
             length += " '"+df.columns[name]+"'n $"+str(col_l)
+            if keep_outer_quotes:
+               input  += "~ "
             dts.append('C')
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):


### PR DESCRIPTION
Add option keep_outer_quotes to the sasdata2dataframe methods since the default for SAS is to strip them off. sasoptpy requested this as it needed to have quoted variables in the SAS data set it uses for optimization. 