### PR TITLE
fix tabulate code compatibility for python3 < python3.5

### DIFF
--- a/saspy/__init__.py
+++ b/saspy/__init__.py
@@ -20,7 +20,7 @@ from saspy.sasml          import *
 from saspy.sasqc          import *
 from saspy.sasresults     import *
 from saspy.sasutil        import *
-#from saspy.sastabulate    import *
+from saspy.sastabulate    import *
 from saspy.sasproccommons import *
 from saspy.SASLogLexer    import *
 from saspy.version        import __version__
@@ -38,5 +38,5 @@ def isnotebook():
         return False      # Probably standard Python interpreter
 
 if isnotebook():
-        from .sas_magic import SASMagic
-        get_ipython().register_magics(SASMagic)
+	from .sas_magic import SASMagic
+	get_ipython().register_magics(SASMagic)

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -69,7 +69,7 @@ from saspy.sasml import *
 from saspy.sasqc import *
 from saspy.sasutil import *
 from saspy.sasresults import *
-#from saspy.sastabulate import Tabulate
+from saspy.sastabulate import Tabulate
 
 try:
     from IPython.display import HTML
@@ -1044,7 +1044,7 @@ class SASdata:
         self.table = table
         self.dsopts = dsopts
         self.results = results
-        #self.tabulate = Tabulate(sassession, self)
+        self.tabulate = Tabulate(sassession, self)
 
     def __getitem__(self, key):
 

--- a/saspy/sastabulate.py
+++ b/saspy/sastabulate.py
@@ -1,5 +1,6 @@
 import logging
 import pandas as pd
+from collections import ChainMap 
 from saspy.sasresults import SASresults
 from saspy.sasproccommons import SASProcCommons
 try:
@@ -177,12 +178,7 @@ class Tabulate:
     @staticmethod
     def classes(*args, labels=[]):
         label_kwargs = build_kwargs('label', labels, len(args))
-        ret = []
-        for i in range(len(args)):
-           ret.append(Class(args[i], **label_kwargs[i]))
-
-        return ret
-        #return [Class(args[i], **label_kwargs[i]) for i in range(len(args))]
+        return [Class(args[i], **label_kwargs[i]) for i in range(len(args))]
 
     @staticmethod
     def as_var(*args, **kwargs):
@@ -191,12 +187,7 @@ class Tabulate:
     @staticmethod
     def vars(*args, labels=[]):
         label_kwargs = build_kwargs('label', labels, len(args))
-        ret = []
-        for i in range(len(args)):
-           ret.append(Var(args[i], **label_kwargs[i]))
-
-        return ret
-        #return [Var(args[i], **label_kwargs[i]) for i in range(len(args))]
+        return [Var(args[i], **label_kwargs[i]) for i in range(len(args))]
 
     @staticmethod
     def stat(*args, **kwargs):
@@ -206,12 +197,10 @@ class Tabulate:
     def stats(*args, labels=[], formats=[]):
         label_kwargs = build_kwargs('label', labels, len(args))
         format_kwargs = build_kwargs('format', formats, len(args))
-        ret = []
-        for i in range(len(args)):
-           ret.append(Statistic(args[i], **label_kwargs[i], **format_kwargs[i]))
-
-        return ret
-        #return [Statistic(args[i], **label_kwargs[i], **format_kwargs[i]) for i in range(len(args))]
+        return [
+            Statistic(args[i], **dict(ChainMap(label_kwargs[i], format_kwargs[i]))) 
+            for i in range(len(args))
+        ]
 
     def table(self, **kwargs: dict) -> 'SASresults':
         """


### PR DESCRIPTION
Fix for #145 

For the one use of unpacking 2 dicts as a function argument (a capability added in python3.5), this PR swaps in a common use of ChainMap (part of the collections module, standard lib) for alternative syntax that is compatible with python3 prior to 3.5. 

I've run the tests successfully on 3.4 after this change. 

(I'm still interested in pursuing something like Travis CI for this library so that all commits can undergo automated testing against the array of python versions supported, to spot any compat gaps - but that would be tricky since the tests use live connections to a SAS session, rather than mocks etc. Perhaps some offline-only tests could be added that simply ensure the library fully imports without error, and those could be run on every python version supported as part of a CI suite?)