### PR TITLE
Moved direct calls to logging to each class's existing logger instead

### DIFF
--- a/saspy/sasViyaML.py
+++ b/saspy/sasViyaML.py
@@ -52,7 +52,7 @@ class SASViyaML:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sas = session
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
 
     def factmac(self, **kwargs: dict) -> object:
         """
@@ -69,8 +69,8 @@ class SASViyaML:
         required_set = {'input', 'target'}
         legal_set = {'freq', 'input', 'id', 'target', 'save', 'score', 'procopts'}
         # print ("I am HERE")
-        logging.debug("kwargs type: " + str(type(kwargs)))
-        return SASProcCommons._run_proc("HPFOREST", required_set, legal_set, **kwargs)
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
+        return SASProcCommons._run_proc(self, "HPFOREST", required_set, legal_set, **kwargs)
 
     def forest(self, **kwargs: dict) -> object:
         """
@@ -86,8 +86,8 @@ class SASViyaML:
         """
         required_set = {'input'}
         legal_set = {'freq', 'input', 'id', 'score', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
-        return SASProcCommons._run_proc("HPCLUS", required_set, legal_set, **kwargs)
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
+        return SASProcCommons._run_proc(self, "HPCLUS", required_set, legal_set, **kwargs)
 
     def gradboost(self, **kwargs: dict) -> object:
         """
@@ -103,8 +103,8 @@ class SASViyaML:
         """
         required_set = {'input'}
         legal_set = {'freq', 'input', 'id', 'score', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
-        return SASProcCommons._run_proc("HPCLUS", required_set, legal_set, **kwargs)
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
+        return SASProcCommons._run_proc(self, "HPCLUS", required_set, legal_set, **kwargs)
 
     def nnet(self, **kwargs: dict) -> object:
         """
@@ -121,8 +121,8 @@ class SASViyaML:
         required_set = {'input', 'target', 'train'}
         legal_set = {'freq', 'input', 'id', 'target', 'save', 'score',
                      'architecture', 'weight', 'hidden', 'partition', 'train', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
-        return SASProcCommons._run_proc("HPNEURAL", required_set, legal_set, **kwargs)
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
+        return SASProcCommons._run_proc(self, "HPNEURAL", required_set, legal_set, **kwargs)
 
     def svmachine(self, **kwargs: dict) -> object:
         """

--- a/saspy/sasml.py
+++ b/saspy/sasml.py
@@ -49,7 +49,7 @@ class SASml:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sas = session
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
 
     def forest(self, **kwargs: dict) -> 'SASresults':
         """
@@ -68,7 +68,7 @@ class SASml:
         """
         required_set = {'input', 'target'}
         legal_set = {'freq', 'input', 'id', 'target', 'save', 'score', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPFOREST", required_set, legal_set, **kwargs)
 
     def hp4score(self, **kwargs: dict) -> 'SASresults':
@@ -87,7 +87,7 @@ class SASml:
         """
         required_set = {}
         legal_set = {'id', 'importance', 'performance', 'score', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HP4SCORE", required_set, legal_set, **kwargs)
 
     def cluster(self, **kwargs: dict) -> 'SASresults':
@@ -106,7 +106,7 @@ class SASml:
         """
         required_set = {'input'}
         legal_set = {'freq', 'input', 'id', 'score', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPCLUS", required_set, legal_set, **kwargs)
 
     def neural(self, **kwargs: dict) -> 'SASresults':
@@ -128,7 +128,7 @@ class SASml:
         legal_set = {'architecture', 'code', 'hidden', 'id', 'input',
                      'partition', 'score', 'target', 'train',
                      'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPNEURAL", required_set, legal_set, **kwargs)
 
     def treeboost(self, **kwargs: dict) -> 'SASresults':
@@ -149,7 +149,7 @@ class SASml:
         required_set = {'input', 'target'}
         legal_set = {'assess', 'code', 'freq', 'importance', 'input', 'performance', 'target', 'save', 'score',
                      'subseries', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "TREEBOOST", required_set, legal_set, **kwargs)
 
     def hpbnet(self, **kwargs: dict) -> 'SASresults':
@@ -168,5 +168,5 @@ class SASml:
         """
         required_set = {'input', 'target'}
         legal_set = {'id', 'code', 'freq', 'partition', 'input', 'performance', 'target', 'output', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPBNET", required_set, legal_set, **kwargs)

--- a/saspy/sasproccommons.py
+++ b/saspy/sasproccommons.py
@@ -26,7 +26,7 @@ class SASProcCommons:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sas = session
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
 
     @staticmethod
     def _errorLog(log):

--- a/saspy/sasqc.py
+++ b/saspy/sasqc.py
@@ -49,7 +49,7 @@ class SASqc:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sas = session
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
     
     def cusum(self, **kwargs: dict) -> 'SASresults':
         """
@@ -64,7 +64,7 @@ class SASqc:
         """
         required_set = {}
         legal_set = {'by', 'xchart', 'procopts'}
-        logger.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "CUSUM", required_set, legal_set, **kwargs)
 
     def macontrol(self, **kwargs: dict) -> 'SASresults':
@@ -78,7 +78,7 @@ class SASqc:
         """
         required_set = {}
         legal_set = {'procopts'}
-        logger.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "MACONTROL", required_set, legal_set, **kwargs)
 
     def capability(self, **kwargs: dict) -> 'SASresults':
@@ -95,7 +95,7 @@ class SASqc:
         required_set = {}
         legal_set = {'cdfplot', 'comphist', 'histogram', 'inset', 'intervals', 'output', 'ppplot', 'probplot',
                      'qqplot', 'freq', 'weight', 'id', 'by', 'spec', 'out', 'procopts'}
-        logger.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "CAPABILITY", required_set, legal_set, **kwargs)
 
     def shewhart(self, **kwargs: dict) -> 'SASresults':
@@ -107,6 +107,6 @@ class SASqc:
         """
         required_set = {}
         legal_set = {'procopts'}
-        logger.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "SHEWHART", required_set, legal_set, **kwargs)
 

--- a/saspy/sasstat.py
+++ b/saspy/sasstat.py
@@ -51,7 +51,7 @@ class SASstat:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sas = session
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
 
     def hpsplit(self, **kwargs: dict) -> 'SASresults':
         """
@@ -72,7 +72,7 @@ class SASstat:
         required_set = {}
         legal_set = {'cls', 'code', 'grow', 'id', 'model', 'out',
                      'partition', 'performance', 'prune', 'rules', 'target', 'input', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPSPLIT", required_set, legal_set, **kwargs)
 
     def reg(self, **kwargs: dict) -> 'SASresults':
@@ -97,7 +97,7 @@ class SASstat:
                      'lsmeans', 'model', 'random', 'repeated',
                      'slice', 'test', 'weight', 'out', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "REG", required_set, legal_set, **kwargs)
 
     def mixed(self, **kwargs: dict) -> 'SASresults':
@@ -123,7 +123,7 @@ class SASstat:
                      'lsmeans', 'model', 'out', 'random', 'repeated',
                      'slice', 'weight', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "MIXED", required_set, legal_set, **kwargs)
 
     def glm(self, **kwargs: dict) -> 'SASresults':
@@ -150,7 +150,7 @@ class SASstat:
                      'lsmeans', 'manova', 'means', 'model', 'out', 'random', 'repeated',
                      'test', 'weight', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "GLM", required_set, legal_set, **kwargs)
 
     def logistic(self, **kwargs: dict) -> 'SASresults':
@@ -183,7 +183,7 @@ class SASstat:
                      'exact', 'freq', 'lsmeans', 'oddsratio', 'out', 'roc', 'score', 'slice',
                      'store', 'strata', 'units', 'weight', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "LOGISTIC", required_set, legal_set, **kwargs)
 
     def tpspline(self, **kwargs: dict) -> 'SASresults':
@@ -207,7 +207,7 @@ class SASstat:
         required_set = {'model'}
         legal_set = {'by', 'freq', 'id', 'model', 'output', 'score', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "TPSPLINE", required_set, legal_set, **kwargs)
 
     def hplogistic(self, **kwargs: dict) -> 'SASresults':
@@ -232,7 +232,7 @@ class SASstat:
         legal_set = {'by', 'cls', 'code', 'freq', 'id', 'model', 'out',
                      'partition', 'score', 'selection', 'weight'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
 
         # ODS graphics are created by default for STAT this stops them form generation
         kwargs['ODSGraphics']=False
@@ -260,7 +260,7 @@ class SASstat:
         legal_set = {'by', 'cls', 'code', 'freq', 'id', 'model', 'out',
                      'partition', 'performance', 'score', 'selection', 'weight'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         kwargs['ODSGraphics']=False
         return SASProcCommons._run_proc(self, "HPREG", required_set, legal_set, **kwargs)
 
@@ -288,7 +288,7 @@ class SASstat:
                      'hazardratio', 'id', 'lsmeans', 'lsmestimate', 'model', 'out', 'roc',
                      'random', 'slice', 'store', 'strata', 'test', 'weight', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         kwargs['ODSGraphics']=True
         return SASProcCommons._run_proc(self, "PHREG", required_set, legal_set, **kwargs)
 
@@ -312,7 +312,7 @@ class SASstat:
         required_set = {}
         legal_set = {'by', 'cls', 'freq', 'paired', 'var', 'weight', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         kwargs['ODSGraphics']=True
         return SASProcCommons._run_proc(self, "TTEST", required_set, legal_set, **kwargs)
 
@@ -334,7 +334,7 @@ class SASstat:
         required_set = {}
         legal_set = {'by', 'freq', 'priors', 'pathdiagram', 'partial', 'var', 'weight', 'procopts'}
 
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         kwargs['ODSGraphics']=True
         return SASProcCommons._run_proc(self, "FACTOR", required_set, legal_set, **kwargs)
 

--- a/saspy/sastabulate.py
+++ b/saspy/sastabulate.py
@@ -169,7 +169,7 @@ class Tabulate:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sasproduct = 'base'
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
 
     @staticmethod
     def as_class(*args, **kwargs):

--- a/saspy/sasutil.py
+++ b/saspy/sasutil.py
@@ -55,7 +55,7 @@ class SASutil:
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.WARN)
         self.sas = session
-        logging.debug("Initialization of SAS Macro: " + self.sas.saslog())
+        self.logger.debug("Initialization of SAS Macro: " + self.sas.saslog())
 
     def hpimpute(self, **kwargs: dict) -> 'SASresults':
         """
@@ -75,7 +75,7 @@ class SASutil:
         required_set = {'impute'}
         legal_set = {'input', 'impute', 'performance', 'id', 'freq', 'code',
                      'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPIMPUTE", required_set, legal_set, **kwargs)
 
     def hpbin(self, **kwargs: dict) -> 'SASresults':
@@ -96,7 +96,7 @@ class SASutil:
         """
         required_set = {}
         legal_set = {'code', 'id', 'performance', 'target', 'input', 'procopts'}
-        logging.debug("kwargs type: " + str(type(kwargs)))
+        self.logger.debug("kwargs type: " + str(type(kwargs)))
         return SASProcCommons._run_proc(self, "HPBIN", required_set, legal_set, **kwargs)
 
 


### PR DESCRIPTION
Each of the files changed was calling the root logger directly, this change fixes that so that each file correctly uses it's own logger.

Signed-off-by: Wesley Rogers <wsrogers3@catamount.wcu.edu>
