### PR TITLE
Zeppelin

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -477,10 +477,6 @@ class SASsession():
 
         ll = self._io.submit(code, results, prompt)
 
-        if results.upper() == 'HTML':
-           if self.sascfg.zep: 
-              ll['LST'] = self.HTML(ll['LST'])
-
         return ll
 
     def saslog(self) -> str:

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -477,7 +477,7 @@ class SASsession():
 
         ll = self._io.submit(code, results, prompt)
 
-        if results.upper == 'HTML':
+        if results.upper() == 'HTML':
            if self.sascfg.zep: 
               ll['LST'] = self.HTML(ll['LST'])
 

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -164,11 +164,24 @@ class SASconfig:
         ssh           = cfg.get('ssh',      '')
         path          = cfg.get('saspath',  '')
         java          = cfg.get('java',     '')
-        self.zep      = cfg.get('zeppelin', False)
+        self.display  = cfg.get('display',  '')
         self.results  = cfg.get('results',  None)
         self.autoexec = cfg.get('autoexec', None)
 
-        if self.zep:
+        indisplay = kwargs.get('display', '')
+        if len(indisplay) > 0:
+           if lock and len(self.display):
+              print("Parameter 'display' passed to SAS_session was ignored due to configuration restriction.")
+           else:
+              self.display = indisplay
+        if self.display == '':
+           self.display = 'jupyter'
+        else:
+           if self.display.lower() not in ['zeppelin', 'jupyter']:
+              print("Invalid value specified for 'display'. Using the default of 'jupyter'")
+              self.display = 'jupyter'
+
+        if self.display.lower() == 'zeppelin':
            self.DISPLAY = zepDISPLAY
            self.HTML    = zepHTML
         else:
@@ -458,7 +471,7 @@ class SASsession():
 
         NOTE: to view HTML results in the ipykernel, issue: from IPython.display import HTML  and use HTML() instead of print()
 
-        In Zeppelin, the html LST results can be displayed via print(ll['LST']) as they already have the "%html " prepended.
+        In Zeppelin, the html LST results can be displayed via print("%html "+ ll['LST']) to diplay as HTML.
 
         i.e,: results = sas.submit("data a; x=1; run; proc print;run')
                       print(results['LOG'])

--- a/saspy/sasdata.py
+++ b/saspy/sasdata.py
@@ -61,21 +61,24 @@ class SASdata:
         self.logger = logging.getLogger(__name__)
 
         if results == '':
-            results = sassession.results
+           results = sassession.results
 
         failed = 0
         if results.upper() == "HTML":
-            try:
-                from IPython.display import HTML
-            except:
-                failed = 1
-
-            if failed and not self.sas.batch:
-                self.HTML = 0
-            else:
-                self.HTML = 1
+           if self.sas.sascfg.display.lower() == 'jupyter':
+              try:
+                 from IPython.display import HTML
+              except:
+                 failed = 1
+              
+              if failed and not self.sas.batch:
+                  self.HTML = 0
+              else:
+                  self.HTML = 1
+           else:
+              self.HTML = 1
         else:
-            self.HTML = 0
+           self.HTML = 0
 
         if len(libref):
             self.libref = libref

--- a/saspy/sasdata.py
+++ b/saspy/sasdata.py
@@ -23,12 +23,6 @@ try:
 except ImportError:
     pass
 
-try:
-    from IPython.display import HTML
-    from IPython.display import display as DISPLAY
-except ImportError:
-    pass
-
 class SASdata:
     """
     **Overview**
@@ -71,9 +65,7 @@ class SASdata:
 
         failed = 0
         if results.upper() == "HTML":
-            try:
-                from IPython.display import HTML
-            except:
+            if self.sas.HTML('') == "IPython didn't import. Can't render HTML":
                 failed = 1
 
             if failed and not self.sas.batch:
@@ -216,7 +208,7 @@ class SASdata:
                 if not ll:
                     ll = self.sas._io.submit(code)
                 if not self.sas.batch:
-                    DISPLAY(HTML(ll['LST']))
+                    self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                 else:
                     return ll
             else:
@@ -274,7 +266,7 @@ class SASdata:
                 else:
                     ll = le
                 if not self.sas.batch:
-                    DISPLAY(HTML(ll['LST']))
+                    self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                 else:
                     return ll
             else:
@@ -476,7 +468,7 @@ class SASdata:
                 if not ll:
                     ll = self.sas._io.submit(code)
                 if not self.sas.batch:
-                    DISPLAY(HTML(ll['LST']))
+                    self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                 else:
                     return ll
             else:
@@ -509,7 +501,7 @@ class SASdata:
                 if not ll:
                     ll = self.sas._io.submit(code)
                 if not self.sas.batch:
-                    DISPLAY(HTML(ll['LST']))
+                    self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                 else:
                     return ll
             else:
@@ -606,7 +598,7 @@ class SASdata:
                if not ll:
                   ll = self.sas._io.submit(code)
                if not self.sas.batch:
-                  DISPLAY(HTML(ll['LST']))
+                  self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                else:
                   return ll
             else:
@@ -964,7 +956,7 @@ class SASdata:
             ll = self.sas._io.submit(code)
             self.HTML = html
         if not self.sas.batch:
-            DISPLAY(HTML(ll['LST']))
+            self.sas.DISPLAY(self.sas.HTML(ll['LST']))
         else:
             return ll
 
@@ -1084,7 +1076,7 @@ class SASdata:
             ll = self.sas._io.submit(code)
             self.HTML = html
         if not self.sas.batch:
-            DISPLAY(HTML(ll['LST']))
+            self.sas.DISPLAY(self.sas.HTML(ll['LST']))
         else:
             return ll
 
@@ -1118,7 +1110,7 @@ class SASdata:
             ll = self.sas._io.submit(code)
             self.HTML = html
         if not self.sas.batch:
-            DISPLAY(HTML(ll['LST']))
+            self.sas.DISPLAY(self.sas.HTML(ll['LST']))
         else:
             return ll
 
@@ -1156,7 +1148,7 @@ class SASdata:
                 if not ll:
                     ll = self.sas._io.submit(code)
                 if not self.sas.batch:
-                    DISPLAY(HTML(ll['LST']))
+                    self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                 else:
                     return ll
             else:
@@ -1197,7 +1189,7 @@ class SASdata:
             ll = self.sas._io.submit(code)
             self.HTML = html
         if not self.sas.batch:
-            DISPLAY(HTML(ll['LST']))
+            self.sas.DISPLAY(self.sas.HTML(ll['LST']))
         else:
             return ll
 
@@ -1237,7 +1229,7 @@ class SASdata:
             ll = self.sas._io.submit(code)
             self.HTML = html
         if not self.sas.batch:
-            DISPLAY(HTML(ll['LST']))
+            self.sas.DISPLAY(self.sas.HTML(ll['LST']))
         else:
             return ll
 
@@ -1277,6 +1269,7 @@ class SASdata:
             ll = self.sas._io.submit(code)
             self.HTML = html
         if not self.sas.batch:
-            DISPLAY(HTML(ll['LST']))
+            self.sas.DISPLAY(self.sas.HTML(ll['LST']))
         else:
             return ll
+

--- a/saspy/sasdata.py
+++ b/saspy/sasdata.py
@@ -65,7 +65,9 @@ class SASdata:
 
         failed = 0
         if results.upper() == "HTML":
-            if self.sas.HTML('') == "IPython didn't import. Can't render HTML":
+            try:
+                from IPython.display import HTML
+            except:
                 failed = 1
 
             if failed and not self.sas.batch:

--- a/saspy/sasresults.py
+++ b/saspy/sasresults.py
@@ -47,7 +47,7 @@ class SASresults(object):
         if attr.startswith('_'):
             return getattr(self, attr)
         if attr.upper() == 'LOG' or attr.upper() == 'ERROR_LOG':
-            if self.sas.sascfg.zep:
+            if self.sas.sascfg.display.lower() == 'zeppelin':
                if not self.sas.batch:
                    self.sas.DISPLAY(self.sas.HTML(self._colorLog(self._log)))
                else:
@@ -114,10 +114,10 @@ class SASresults(object):
                if i.upper()!='LOG':
                    x = self.__getattr__(i)
                    if isinstance(x, pd.DataFrame):
-                      if not self.sas.sascfg.zep:
-                         self.sas.DISPLAY(x)
-                      else:
+                      if self.sas.sascfg.display.lower() == 'zeppelin':
                          print("%text "+i+"\n"+str(x)+"\n")
+                      else:
+                         self.sas.DISPLAY(x)
         else:
            ret = []
            for i in self._names:

--- a/saspy/sasresults.py
+++ b/saspy/sasresults.py
@@ -52,9 +52,10 @@ class SASresults(object):
                    self.sas.DISPLAY(self.sas.HTML(self._colorLog(self._log)))
                else:
                    print(self._log)
+               return
             else:
                if not self.sas.batch:
-                   return HTML(self._colorLog(self._log))
+                   return self.sas.HTML(self._colorLog(self._log))
                else:
                    return self._log
 
@@ -72,11 +73,7 @@ class SASresults(object):
            if isinstance(data, pd.DataFrame):
                return data
            else:
-               if self.sas.sascfg.zep:
-                   self.sas.DISPLAY(self.sas.HTML('<h1>' + attr + '</h1>' + data['LST']))
-                   return None
-               else:
-                   return data
+               self.sas.DISPLAY(self.sas.HTML('<h1>' + attr + '</h1>' + data['LST']))
         else:
            return data
 
@@ -117,8 +114,10 @@ class SASresults(object):
                if i.upper()!='LOG':
                    x = self.__getattr__(i)
                    if isinstance(x, pd.DataFrame):
-                      print("%text "+i+"\n"+str(x)+"\n")
-           return None
+                      if not self.sas.sascfg.zep:
+                         self.sas.DISPLAY(x)
+                      else:
+                         print("%text "+i+"\n"+str(x)+"\n")
         else:
            ret = []
            for i in self._names:

--- a/saspy/sastabulate.py
+++ b/saspy/sastabulate.py
@@ -5,11 +5,6 @@ try:
     import pandas as pd
 except ImportError:
     pass
-try:
-    from IPython.display import HTML
-    from IPython.display import display as DISPLAY
-except ImportError:
-    pass
 
 from collections import ChainMap
 import saspy as sp
@@ -315,7 +310,7 @@ class Tabulate:
                 ll = self.sas._io.submit(code)
                 self.data.HTML = html
             if not self.sas.batch:
-                DISPLAY(HTML(ll['LST']))
+                self.sas.DISPLAY(self.sas.HTML(ll['LST']))
                 check, errorMsg = self.data._checkLogForError(ll['LOG'])
                 if not check:
                     raise ValueError("Internal code execution failed: " + errorMsg)


### PR DESCRIPTION
Gonna merge this into master and do more testing and validation. Then build the 2.4.4 version to contain this. No changes required for any existing saspy jobs on Jupyter or line-mode or batch. To support Zeppelin (a different display method than jupyter), a new configuration definition key is required. The default for this not being set, is still jupyter. So this has to be explicitly set to drive the Zeppelin display method instead of the jupyter display method. Also, other methods can be added if ever need be. How to display and render html is now vectored like access methods. So adding others shouldn't be a problem.

```
display -
This is a new key to support Zeppelin (saspy V2.4.4). The values can be either ‘jupyter’ or ‘zeppelin’. 
The default when this is not specified is ‘jupyter’. Jupyter uses IPython to render HTML, which is how saspy has always worked.
To support Zeppelin’s display method, a different display interface had to be added to saspy.
If you want to run saspy in Zeppelin, set this in your configuration definition: ‘display’ : ‘zeppelin’,
```
Tom