### PR TITLE
Add SASConfigNotValidError and SASIONotSupportedError

### DIFF
--- a/saspy/__init__.py
+++ b/saspy/__init__.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from saspy.version import __version__
 from saspy.sasbase import SASsession, SASconfig
 from saspy.sasdata import SASdata
+from saspy.sasexceptions import SASIONotSupportedError, SASConfigNotValidError
 from saspy.sasproccommons import SASProcCommons
 from saspy.sastabulate import Tabulate
 from saspy.sasresults import SASresults

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -41,14 +41,15 @@ import sys
 import getpass
 import tempfile
 
-from saspy.sasioiom  import SASsessionIOM
-from saspy.sasets    import SASets
-from saspy.sasml     import SASml
-from saspy.sasqc     import SASqc
-from saspy.sasstat   import SASstat
-from saspy.sasutil   import SASutil
-from saspy.sasViyaML import SASViyaML
-from saspy.sasdata   import SASdata
+from saspy.sasioiom      import SASsessionIOM
+from saspy.sasets        import SASets
+from saspy.sasexceptions import SASIONotSupportedError
+from saspy.sasml         import SASml
+from saspy.sasqc         import SASqc
+from saspy.sasstat       import SASstat
+from saspy.sasutil       import SASutil
+from saspy.sasViyaML     import SASViyaML
+from saspy.sasdata       import SASdata
 
 try:
    import pandas as pd
@@ -316,73 +317,73 @@ class SASsession():
             if os.name != 'nt':
                 self._io = SASsessionSTDIO(sascfgname=self.sascfg.name, sb=self, **kwargs)
             else:
-                print("Cannot use STDIO I/O module on Windows. No "
-                    "SASsession established. Choose an IOM SASconfig " 
-                    "definition")
+                raise SASIONotSupportedError(self.sascfg.mode, alts=['IOM'])
         elif self.sascfg.mode == 'IOM':
             self._io = SASsessionIOM(sascfgname=self.sascfg.name, sb=self, **kwargs)
 
         try:
-            if self._io.pid:
-                sysvars = """options nosource;
-                    %put WORKPATH=%sysfunc(pathname(work));
-                    %put ENDWORKPATH=;
-                    %put ENCODING=&SYSENCODING;
-                    %put SYSVLONG=&SYSVLONG4;
-                    %put SYSJOBID=&SYSJOBID;
-                    %put SYSSCP=&SYSSCP;
-                    options source;
-                """
-                enc = self._io.sascfg.encoding #validating encoding is done next, so handle it not being set for this one call
-                if enc == '':
-                   self._io.sascfg.encoding = 'utf_8'
-                res = self.submit(sysvars, "text")['LOG']
-                self._io.sascfg.encoding = enc
+            sysvars = """options nosource;
+                %put WORKPATH=%sysfunc(pathname(work));
+                %put ENDWORKPATH=;
+                %put ENCODING=&SYSENCODING;
+                %put SYSVLONG=&SYSVLONG4;
+                %put SYSJOBID=&SYSJOBID;
+                %put SYSSCP=&SYSSCP;
+                options source;
+            """
+            # Validating encoding is done next, so handle it not being set for
+            # this one call
+            enc = self._io.sascfg.encoding
+            if enc == '':
+               self._io.sascfg.encoding = 'utf_8'
+            res = self.submit(sysvars, "text")['LOG']
+            self._io.sascfg.encoding = enc
 
-                vlist         = res.rpartition('SYSSCP=')
-                self.hostsep  = vlist[2].partition('\n')[0]
-                vlist         = res.rpartition('SYSJOBID=')
-                self.SASpid   = vlist[2].partition('\n')[0]
-                vlist         = res.rpartition('SYSVLONG=')
-                self.sasver   = vlist[2].partition('\n')[0]
-                vlist         = res.rpartition('ENCODING=')
-                self.sascei   = vlist[2].partition('\n')[0]
-                vlist         = res.rpartition('\nENDWORKPATH=')
-                self.workpath = vlist[0].rpartition('WORKPATH=')[2].strip().replace('\n','') 
+            vlist         = res.rpartition('SYSSCP=')
+            self.hostsep  = vlist[2].partition('\n')[0]
+            vlist         = res.rpartition('SYSJOBID=')
+            self.SASpid   = vlist[2].partition('\n')[0]
+            vlist         = res.rpartition('SYSVLONG=')
+            self.sasver   = vlist[2].partition('\n')[0]
+            vlist         = res.rpartition('ENCODING=')
+            self.sascei   = vlist[2].partition('\n')[0]
+            vlist         = res.rpartition('\nENDWORKPATH=')
+            self.workpath = vlist[0].rpartition('WORKPATH=')[2].strip().replace('\n','') 
 
-                # validate encoding
-                pyenc = sas_encoding_mapping[self.sascei]
-                if pyenc is not None:
-                   if self._io.sascfg.encoding != '':
-                      if self._io.sascfg.encoding.lower() not in pyenc:
-                         print("The encoding value provided doesn't match the SAS session encoding.")
-                         print("SAS encoding is "+self.sascei+". Specified encoding is "+self._io.sascfg.encoding+".")
-                         print("Using encoding "+pyenc[0]+" instead to avoid transcoding problems.")
-                         self._io.sascfg.encoding = pyenc[0]
-                         print("You can override this change, if you think you must, by changing the encoding attribute of the SASsession object, as follows.")
-                         print("""If you had 'sas = saspy.SASsession(), then submit: "sas._io.sascfg.encoding='override_encoding'" to change it""")
-                   else:
-                      self._io.sascfg.encoding = pyenc[0]
-                      if self._io.sascfg.verbose:
-                         print("No encoding value provided. Will try to determine the correct encoding.")
-                         print("Setting encoding to "+pyenc[0]+" based upon the SAS session encoding value of "+self.sascei+".")
-                else:
-                   print("The SAS session encoding for this session ("+self.sasce+") doesn't have a known Python equivalent encoding.")
-                   if self._io.sascfg.encoding == '':
-                      self._io.sascfg.encoding  = 'utf_8'
-                      print("Proceeding using the default encoding of 'utf_8', though you may encounter transcoding problems.")
-                   else:
-                      print("Proceeding using the specified encoding of "+self._io.sascfg.encoding+", though you may encounter transcoding problems.")
+            # validate encoding
+            pyenc = sas_encoding_mapping[self.sascei]
+            if pyenc is not None:
+               if self._io.sascfg.encoding != '':
+                  if self._io.sascfg.encoding.lower() not in pyenc:
+                     print("The encoding value provided doesn't match the SAS session encoding.")
+                     print("SAS encoding is "+self.sascei+". Specified encoding is "+self._io.sascfg.encoding+".")
+                     print("Using encoding "+pyenc[0]+" instead to avoid transcoding problems.")
+                     self._io.sascfg.encoding = pyenc[0]
+                     print("You can override this change, if you think you must, by changing the encoding attribute of the SASsession object, as follows.")
+                     print("""If you had 'sas = saspy.SASsession(), then submit: "sas._io.sascfg.encoding='override_encoding'" to change it""")
+               else:
+                  self._io.sascfg.encoding = pyenc[0]
+                  if self._io.sascfg.verbose:
+                     print("No encoding value provided. Will try to determine the correct encoding.")
+                     print("Setting encoding to "+pyenc[0]+" based upon the SAS session encoding value of "+self.sascei+".")
+            else:
+               print("The SAS session encoding for this session ("+self.sasce+") doesn't have a known Python equivalent encoding.")
+               if self._io.sascfg.encoding == '':
+                  self._io.sascfg.encoding  = 'utf-8'
+                  print("Proceeding using the default encoding of 'utf-8', though you may encounter transcoding problems.")
+               else:
+                  print("Proceeding using the specified encoding of "+self._io.sascfg.encoding+", though you may encounter transcoding problems.")
 
-                if self.hostsep == 'WIN':
-                    self.hostsep = '\\'
-                else:
-                    self.hostsep = '/'
-                self.workpath = self.workpath + self.hostsep
+            if self.hostsep == 'WIN':
+                self.hostsep = '\\'
+            else:
+                self.hostsep = '/'
+            self.workpath = self.workpath + self.hostsep
 
-                if self.sascfg.autoexec:
-                    self.submit(self.sascfg.autoexec)
+            if self.sascfg.autoexec:
+                self.submit(self.sascfg.autoexec)
 
+        # FIXME: What causes this AttributeError?
         except (AttributeError):
             self._io = None
 

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -321,71 +321,66 @@ class SASsession():
         elif self.sascfg.mode == 'IOM':
             self._io = SASsessionIOM(sascfgname=self.sascfg.name, sb=self, **kwargs)
 
-        try:
-            sysvars = """options nosource;
-                %put WORKPATH=%sysfunc(pathname(work));
-                %put ENDWORKPATH=;
-                %put ENCODING=&SYSENCODING;
-                %put SYSVLONG=&SYSVLONG4;
-                %put SYSJOBID=&SYSJOBID;
-                %put SYSSCP=&SYSSCP;
-                options source;
-            """
-            # Validating encoding is done next, so handle it not being set for
-            # this one call
-            enc = self._io.sascfg.encoding
-            if enc == '':
-               self._io.sascfg.encoding = 'utf_8'
-            res = self.submit(sysvars, "text")['LOG']
-            self._io.sascfg.encoding = enc
+        sysvars = """options nosource;
+            %put WORKPATH=%sysfunc(pathname(work));
+            %put ENDWORKPATH=;
+            %put ENCODING=&SYSENCODING;
+            %put SYSVLONG=&SYSVLONG4;
+            %put SYSJOBID=&SYSJOBID;
+            %put SYSSCP=&SYSSCP;
+            options source;
+        """
+        # Validating encoding is done next, so handle it not being set for
+        # this one call
+        enc = self._io.sascfg.encoding
+        if enc == '':
+           self._io.sascfg.encoding = 'utf_8'
+        res = self.submit(sysvars, "text")['LOG']
+        self._io.sascfg.encoding = enc
 
-            vlist         = res.rpartition('SYSSCP=')
-            self.hostsep  = vlist[2].partition('\n')[0]
-            vlist         = res.rpartition('SYSJOBID=')
-            self.SASpid   = vlist[2].partition('\n')[0]
-            vlist         = res.rpartition('SYSVLONG=')
-            self.sasver   = vlist[2].partition('\n')[0]
-            vlist         = res.rpartition('ENCODING=')
-            self.sascei   = vlist[2].partition('\n')[0]
-            vlist         = res.rpartition('\nENDWORKPATH=')
-            self.workpath = vlist[0].rpartition('WORKPATH=')[2].strip().replace('\n','') 
+        vlist         = res.rpartition('SYSSCP=')
+        self.hostsep  = vlist[2].partition('\n')[0]
+        vlist         = res.rpartition('SYSJOBID=')
+        self.SASpid   = vlist[2].partition('\n')[0]
+        vlist         = res.rpartition('SYSVLONG=')
+        self.sasver   = vlist[2].partition('\n')[0]
+        vlist         = res.rpartition('ENCODING=')
+        self.sascei   = vlist[2].partition('\n')[0]
+        vlist         = res.rpartition('\nENDWORKPATH=')
+        self.workpath = vlist[0].rpartition('WORKPATH=')[2].strip().replace('\n','') 
 
-            # validate encoding
-            pyenc = sas_encoding_mapping[self.sascei]
-            if pyenc is not None:
-               if self._io.sascfg.encoding != '':
-                  if self._io.sascfg.encoding.lower() not in pyenc:
-                     print("The encoding value provided doesn't match the SAS session encoding.")
-                     print("SAS encoding is "+self.sascei+". Specified encoding is "+self._io.sascfg.encoding+".")
-                     print("Using encoding "+pyenc[0]+" instead to avoid transcoding problems.")
-                     self._io.sascfg.encoding = pyenc[0]
-                     print("You can override this change, if you think you must, by changing the encoding attribute of the SASsession object, as follows.")
-                     print("""If you had 'sas = saspy.SASsession(), then submit: "sas._io.sascfg.encoding='override_encoding'" to change it""")
-               else:
-                  self._io.sascfg.encoding = pyenc[0]
-                  if self._io.sascfg.verbose:
-                     print("No encoding value provided. Will try to determine the correct encoding.")
-                     print("Setting encoding to "+pyenc[0]+" based upon the SAS session encoding value of "+self.sascei+".")
-            else:
-               print("The SAS session encoding for this session ("+self.sasce+") doesn't have a known Python equivalent encoding.")
-               if self._io.sascfg.encoding == '':
-                  self._io.sascfg.encoding  = 'utf-8'
-                  print("Proceeding using the default encoding of 'utf-8', though you may encounter transcoding problems.")
-               else:
-                  print("Proceeding using the specified encoding of "+self._io.sascfg.encoding+", though you may encounter transcoding problems.")
+        # validate encoding
+        pyenc = sas_encoding_mapping[self.sascei]
+        if pyenc is not None:
+           if self._io.sascfg.encoding != '':
+              if self._io.sascfg.encoding.lower() not in pyenc:
+                 print("The encoding value provided doesn't match the SAS session encoding.")
+                 print("SAS encoding is "+self.sascei+". Specified encoding is "+self._io.sascfg.encoding+".")
+                 print("Using encoding "+pyenc[0]+" instead to avoid transcoding problems.")
+                 self._io.sascfg.encoding = pyenc[0]
+                 print("You can override this change, if you think you must, by changing the encoding attribute of the SASsession object, as follows.")
+                 print("""If you had 'sas = saspy.SASsession(), then submit: "sas._io.sascfg.encoding='override_encoding'" to change it""")
+           else:
+              self._io.sascfg.encoding = pyenc[0]
+              if self._io.sascfg.verbose:
+                 print("No encoding value provided. Will try to determine the correct encoding.")
+                 print("Setting encoding to "+pyenc[0]+" based upon the SAS session encoding value of "+self.sascei+".")
+        else:
+           print("The SAS session encoding for this session ("+self.sasce+") doesn't have a known Python equivalent encoding.")
+           if self._io.sascfg.encoding == '':
+              self._io.sascfg.encoding  = 'utf_8'
+              print("Proceeding using the default encoding of 'utf_8', though you may encounter transcoding problems.")
+           else:
+              print("Proceeding using the specified encoding of "+self._io.sascfg.encoding+", though you may encounter transcoding problems.")
 
-            if self.hostsep == 'WIN':
-                self.hostsep = '\\'
-            else:
-                self.hostsep = '/'
-            self.workpath = self.workpath + self.hostsep
+        if self.hostsep == 'WIN':
+            self.hostsep = '\\'
+        else:
+            self.hostsep = '/'
+        self.workpath = self.workpath + self.hostsep
 
-            if self.sascfg.autoexec:
-                self.submit(self.sascfg.autoexec)
-
-        # FIXME: What causes this AttributeError?
-        except (AttributeError):
-            self._io = None
+        if self.sascfg.autoexec:
+            self.submit(self.sascfg.autoexec)
 
     def __repr__(self):
         """

--- a/saspy/sasexceptions.py
+++ b/saspy/sasexceptions.py
@@ -1,0 +1,29 @@
+#
+# Copyright SAS Institute
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+class SASIONotSupportedError(Exception):
+    def __init__(self, method: str, alts: list=None):
+        self.method = method
+        self.alts = alts
+
+    def __str__(self):
+        if self.alts is not None:
+            alt_text = 'Try the following: {}'.format(', '.join(self.alts))
+        else:
+            alt_text = ''
+
+        return 'Cannot use {} I/O module on Windows. {}'.format(self.method, alt_text)

--- a/saspy/sasexceptions.py
+++ b/saspy/sasexceptions.py
@@ -15,6 +15,15 @@
 #
 
 
+class SASConfigNotValidError(Exception):
+    def __init__(self, defn: str, msg: str=None):
+        self.defn = defn if defn else 'N/A'
+        self.msg = msg
+
+    def __str__(self):
+        return 'Configuration definition {} is not valid. {}'.format(self.defn, self.msg)
+
+
 class SASIONotSupportedError(Exception):
     def __init__(self, method: str, alts: list=None):
         self.method = method

--- a/saspy/tests/test_sasexceptions.py
+++ b/saspy/tests/test_sasexceptions.py
@@ -1,0 +1,117 @@
+from unittest import mock
+import unittest
+import saspy
+import sys
+import tempfile
+import os
+
+
+CONFIG_STDIO = """
+SAS_config_names = ['default']
+default = {'saspath': '/opt/sasinside/SASHome/SASFoundation/9.4/bin/sas_u8'}
+"""
+CONFIG_SSH = """
+SAS_config_names = ['ssh']
+ssh = {'saspath': '/opt/sasinside/SASHome/SASFoundation/9.4/bin/sas_en',
+    'ssh': '/usr/bin/ssh',
+    'host': 'remote.linux.host',
+    'encoding': 'latin1',
+    'options': ["-fullstimer"]}
+"""
+CONFIG_IOMWIN = """
+SAS_config_names = ['iomwin']
+iomwin = {'java': '/usr/bin/java',
+    'iomhost': 'windows.iom.host',
+    'iomport': 8591,
+    'encoding': 'windows-1252',
+    'classpath': '/dummy/path/to/saspyiom.jar'}
+"""
+CONFIG_INVALID = """
+SAS_config_names = ['not_supported']
+not_supported = {'whatever': 'some value'}
+"""
+
+
+class TestSASExceptions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create dummy config files for test cases. Use `NamedTemporaryFile`
+        instead of in-memory `StringIO` because `SASsession` expects a file
+        path, not a file-like object when passed a `cfgfile`.
+        """
+        # STDIO config file
+        with tempfile.NamedTemporaryFile('w', delete=False) as tf:
+            tf.write(CONFIG_STDIO)
+            cls.config_stdio = tf.name
+
+        # SSH config file
+        with tempfile.NamedTemporaryFile('w', delete=False) as tf:
+            tf.write(CONFIG_SSH)
+            cls.config_ssh = tf.name
+
+        # Windows IOM config file
+        with tempfile.NamedTemporaryFile('w', delete=False) as tf:
+            tf.write(CONFIG_IOMWIN)
+            cls.config_iomwin = tf.name
+
+        # Invalid config file
+        with tempfile.NamedTemporaryFile('w', delete=False) as tf:
+            tf.write(CONFIG_INVALID)
+            cls.config_invalid = tf.name
+
+        # Empty config file
+        with tempfile.NamedTemporaryFile('w', delete=False) as tf:
+            tf.write('')
+            cls.config_empty = tf.name
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean up named temp files
+        """
+        os.unlink(cls.config_stdio)
+        os.unlink(cls.config_ssh)
+        os.unlink(cls.config_iomwin)
+        os.unlink(cls.config_invalid)
+        os.unlink(cls.config_empty)
+
+    def tearDown(self):
+        """
+        Remove `sascfgfile` module after test.
+        """
+        del sys.modules['sascfgfile']
+
+    @mock.patch('os.name', 'nt')
+    def test_raises_SASIONotSupportedError_stdio(self):
+        """
+        Test passing STDIO config option on Windows raises
+        SASIONotSupportedError. Patch os.name to always return 'nt'
+        even on non-Windows systems.
+        """
+        with self.assertRaises(saspy.SASIONotSupportedError):
+            sas = saspy.SASsession(cfgfile=self.config_stdio)
+
+    @mock.patch('os.name', 'nt')
+    def test_raises_SASIONotSupportedError_ssh(self):
+        """
+        Test passing STDIO config option on Windows raises
+        SASIONotSupportedError. Patch os.name to always return 'nt'
+        even on non-Windows systems.
+        """
+        with self.assertRaises(saspy.SASIONotSupportedError):
+            sas = saspy.SASsession(cfgfile=self.config_ssh)
+
+    def test_raises_SASConfigNotValidError_invalid(self):
+        """
+        Test that passing an invalid config raises SASConfigNotValidError.
+        """
+        with self.assertRaises(saspy.SASConfigNotValidError):
+            sas = saspy.SASsession(cfgfile=self.config_invalid)
+
+    def test_raises_SASConfigNotValidError_empty(self):
+        """
+        Test that passing an empty config raises SASConfigNotValidError.
+        """
+        with self.assertRaises(saspy.SASConfigNotValidError):
+            sas = saspy.SASsession(cfgfile=self.config_empty)


### PR DESCRIPTION
Reference issue #218 

Initial commit to add exceptions instead of printing debug statements.

A note about 9bb0441: This seems like a scarier change than it really is. The diff is a bit messy.  The gist of this commit is that since we halt execution now instead of setting `_io = None`, we no longer need to say: `if self._io.pid`.  Likewise, since `_io.pid` should be set by the time we get here, there is no reason to handle the `AttributeError`.  If for whatever reason an attribute is **not** set, it's probably better to stop here instead of setting `_io = None`.  I'm happy to revisit this commit if you feel the exception handling is necessary.