### PR TITLE
Add pandas and numpy to installation dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='saspy',
       packages = ['saspy'],
       cmdclass = {},
       package_data = {'': ['*.js', '*.md', '*.yaml', '*.css', '*.rst'], 'saspy': ['*.sas', 'java/*.*', 'java/pyiom/*.*']},
-      install_requires = ['pygments', 'ipython>=4.0.0'],
+      install_requires = ['pygments', 'ipython>=4.0.0', 'pandas', 'numpy'],
       classifiers = [
         'Programming Language :: Python :: 3',
         "Programming Language :: Python :: 3.4",


### PR DESCRIPTION
The module pandas (and it's dependency numpy) are used throughout this project but are not currently installed as SASPy dependencies.

If SASPy is installed outside of a distribution like Anaconda, this can lead to import errors, especially since the following pattern is not used consistently for conditional imports:

```Python
try:
    import pandas as pd
except ImportError:
    pass
```