### PR TITLE
Unittest Updates

### DIFF
--- a/saspy/tests/test_sasdata.py
+++ b/saspy/tests/test_sasdata.py
@@ -1,318 +1,475 @@
-import os
-import unittest
-
-import pandas as pd
-from IPython.utils.tempdir import TemporaryDirectory
-from pandas.util.testing import assert_frame_equal
-
-import saspy
 from saspy.sasdata import SASdata
 from saspy.sasresults import SASresults
+from pandas.util.testing import assert_frame_equal
+from tempfile import TemporaryDirectory
+import unittest
+import saspy
+import pandas as pd
+import os
+
+
+SALES_QUERY = """
+    proc sql;
+        create table sales as
+        select
+            month,
+            sum(actual) as tot_sales,
+            sum(predict) as predicted_sales
+        from sashelp.prdsale
+        group by month
+        order by month;
+    quit;
+"""
 
 
 class TestSASdataObject(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.sas = saspy.SASsession(results='HTML')
+        cls.sas = saspy.SASsession(results='html')
+        cls.sas.set_batch(True)
+
+        # Contruct a SASdata object that returns results as text
+        cls.cars = cls.sas.sasdata('cars', libref='sashelp', results='text')
 
     @classmethod
     def tearDownClass(cls):
-        if cls.sas:
-            cls.sas._endsas()
+        cls.sas._endsas()
 
-    def test_SASdata(self):
+    def setUp(self):
         """
-        test sasdata method
+        Make sure self.cars defaults to 'text' result type, even if a test
+        modifies it without changing it back. This prevents a cascade of
+        failing tests.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.assertIsInstance(cars, SASdata, msg="cars = sas.sasdata(...) failed")
+        self.cars.set_results('text')
 
-    def test_SASdata_batch(self):
+    def helper_wkcars(self):
         """
-        test set_batch()
+        Create a copy of sashelp.cars in WORK.
+        :return [SASdata]:
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        ll = cars.head()
-        self.assertIsInstance(ll, dict, msg="set_batch(True) didn't return dict")
+        self.sas.submit("data cars; set sashelp.cars; id = _n_; run;")
 
-    def test_SASdata_head(self):
+        return self.sas.sasdata('cars')
+
+    def helper_wkclass(self):
         """
-        test head()
+        Create a copy of sashelp.class in WORK.
+        :return [SASdata]:
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        ll = cars.head()
-        expected = ['1', 'Acura', 'MDX', 'SUV', 'Asia', 'All', '$36,945', '$33,337',
-                    '3.5', '6', '265', '17', '23', '4451', '106', '189']
+        self.sas.submit("data class; set sashelp.class; run;")
+
+        return self.sas.sasdata('class')
+
+    def test_sasdata_construct(self):
+        """
+        Test creation of SASdata object returns the correct type.
+        """
+        self.assertIsInstance(self.cars, SASdata)
+
+    def test_sasdata_contruct_noexist(self):
+        """
+        Test creating a SASdata object for a table that does not exist still
+        returns a SASdata object
+        """
+        notable = self.sas.sasdata('notable', results='text')
+
+        self.assertIsInstance(notable, saspy.SASdata, msg="sas.sasdata(...) failed")
+
+    def test_sasdata_batch_true(self):
+        """
+        Test method set_batch with True argument forces SASdata objects to
+        return dict types on other method calls.
+        """
+        ll = self.cars.head()
+
+        self.assertIsInstance(ll, dict)
+
+    def test_sasdata_head(self):
+        """
+        Test method head returns the first few rows of a dataset.
+        """
+        EXPECTED = ['1', 'Acura', 'MDX', 'SUV', 'Asia', 'All', '$36,945',
+            '$33,337', '3.5', '6', '265', '17', '23', '4451', '106', '189']
+
+        ll = self.cars.head()
         rows = ll['LST'].splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-            retrieved.append(rows[i].split())
-        self.assertIn(expected, retrieved, msg="cars.head() result didn't contain row 1")
+        retrieved = [x.split() for x in rows]
 
-    @unittest.skip("Test failes with extra header info")
-    def test_SASdata_tail(self):
+        self.assertIn(EXPECTED, retrieved, msg="cars.head() result didn't contain first row")
+
+    @unittest.skip("Test fails with extra header info")
+    def test_sasdata_tail(self):
         """
-        test tail()
+        Test method tail returns the last few rows of a dataset.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        ll = cars.tail()
-        expected = ['424', 'Volvo', 'C70', 'LPT', 'convertible', '2dr', 'Sedan', 'Europe', 'Front',
-                    '$40,565', '$38,203', '2.4', '5', '197', '21', '28', '3450', '105', '186']
+        EXPECTED = ['424', 'Volvo', 'C70', 'LPT', 'convertible', '2dr', 'Sedan',
+            'Europe', 'Front', '$40,565', '$38,203', '2.4', '5', '197', '21',
+            '28', '3450', '105', '186']
+
+        ll = self.cars.tail()
         rows = ll['LST'].splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-            retrieved.append(rows[i].split())
-        self.assertIn(expected, retrieved, msg="cars.tail() result didn't contain row 1")
+        retrieved = [x.split() for x in rows]
 
-    def test_SASdata_tailPD(self):
+        self.assertIn(EXPECTED, retrieved, msg="cars.tail() result didn't contain last row")
+
+    def test_sasdata_tail_pandas_instance(self):
         """
-        test tail()
+        Test method tail returns a pandas DataFrame if requested.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='pandas')
-        self.sas.set_batch(True)
-        ll = cars.tail()
-        self.assertEqual(ll.shape, (5, 15), msg="wrong shape returned")
+        self.cars.set_results('pandas')
+        ll = self.cars.tail()
+
         self.assertIsInstance(ll, pd.DataFrame, "Is return type correct")
 
-    def test_SASdata_contents(self):
+    def test_sasdata_tail_pandas_shape(self):
         """
-        test contents()
+        Test method tail returns a correctly shaped pandas DataFrame.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        ll = cars.contents()
-        expected = ['Data', 'Set', 'Name', 'SASHELP.CARS', 'Observations', '428']
-        rows = ll['LST'].splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-            retrieved.append(rows[i].split())
-        self.assertIn(expected, retrieved, msg="cars.contents() result didn't contain expected result")
+        self.cars.set_results('pandas')
+        ll = self.cars.tail()
 
-    def test_SASdata_describe(self):
-        """
-        test describe()
-        """
-        self.skipTest("column output doesn't match the current method. I'm skipping the test for now")
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        ll = cars.describe()
-        expected = ['MSRP', '428', '0', '27635', '32775', '19432', '10280', '20330', '27635']
-        rows = ll['LST'].splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-            retrieved.append(rows[i].split())
-        self.assertIn(expected, retrieved, msg="cars.describe() result didn't contain expected result")
+        self.assertEqual(ll.shape, (5, 15), msg="Wrong shape returned")
 
-    def test_SASdata_describe2(self):
+    def test_sasdata_contents(self):
         """
-        test describe()
+        Test method contents returns the expected data.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp')
-        self.sas.set_batch(True)
-        cars.set_results('PANDAS')
-        ll = cars.describe()
+        EXPECTED = ['Data', 'Set', 'Name', 'SASHELP.CARS', 'Observations', '428']
+
+        ll = self.cars.contents()
+        rows = ll['LST'].splitlines()
+        retrieved = [x.split() for x in rows]
+
+        self.assertIn(EXPECTED, retrieved, msg="cars.contents() result didn't contain expected result")
+
+    @unittest.skip("Column output doesn't match the current method. I'm skipping the test for now")
+    def test_sasdata_describe(self):
+        """
+        Test method describe returns the expected data.
+        """
+        EXPECTED = ['MSRP', '428', '0', '27635', '32775', '19432', '10280', '20330', '27635']
+
+        ll = self.cars.describe()
+        rows = ll['LST'].splitlines()
+        retrieved = [x.split() for x in rows]
+
+        self.assertIn(EXPECTED, retrieved, msg="cars.describe() result didn't contain expected result")
+
+    def test_SASdata_describe_pandas_instance(self):
+        """
+        Test method describe returns a pandas DataFrame if requested.
+        """
+        self.cars.set_results('pandas')
+        ll = self.cars.describe()
+
         self.assertIsInstance(ll, pd.DataFrame, msg='ll is not a dataframe')
-        expected = ['MSRP', '.', 428, 0, 27635, 32774, 19431, 10280, 20329, 27635, 39215, 192465]
-        self.assertEqual([int(elem) for elem in list(ll.iloc[0].dropna())[2:]], expected[2:],
-                         msg="cars.describe() result didn't contain expected result")
-        self.assertEqual(expected[0],list(ll.iloc[0].dropna())[0],
-                         msg="cars.describe() result didn't contain expected result")
 
-    def test_SASdata_results(self):
+    def test_sasdata_describe_pandas_numbers(self):
         """
-        test set_results()
+        Test method describe returns the correct data using a DataFrame.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        cars.set_results('HTML')
-        ll = cars.describe()
-        expected = '<!DOCTYPE html>'
+        EXPECTED = [428, 0, 27635, 32774, 19431, 10280, 20329, 27635, 39215, 192465]
+
+        self.cars.set_results('pandas')
+        ll = self.cars.describe()
+        actual = [int(x) for x in ll.select_dtypes(include=['number']).iloc[0]]
+
+        self.assertEqual(EXPECTED, actual, msg="cars.describe() result didn't contain expected result")
+
+    def test_sasdata_describe_pandas_chars(self):
+        """
+        Test method describe returns the correct data using a DataFrame.
+        """
+        EXPECTED = 'MSRP'
+
+        self.cars.set_results('pandas')
+        ll = self.cars.describe()
+        actual = ll.iloc[0][0]
+
+        self.assertEqual(EXPECTED, actual, msg="cars.describe() result didn't contain expected result")
+
+    def test_sasdata_results_html(self):
+        """
+        Test method set_results appropriately sets the return container.
+        """
+        EXPECTED = '<!DOCTYPE html>'
+
+        self.cars.set_results('html')
+        ll = self.cars.describe()
         row1 = ll['LST'].splitlines()[0]
-        self.assertEqual(expected, row1, msg="cars.set_results() result weren't HTML")
 
-        cars.set_results('TEXT')
-        ll = cars.describe()
+        self.assertEqual(EXPECTED, row1, msg="cars.set_results() result weren't HTML")
+
+    def test_sasdata_results_not_html(self):
+        """
+        Test method set_results appropriately sets the return container.
+        """
+        EXPECTED = '<!DOCTYPE html>'
+
+        self.cars.set_results('text')
+        ll = self.cars.describe()
         row1 = ll['LST'].splitlines()[0]
-        self.assertNotEqual(expected, row1, msg="cars.set_results() result weren't TEXT")
 
-    def test_SASdata_hist(self):
+        self.assertNotEqual(EXPECTED, row1, msg="cars.set_results() result were HTML")
+
+    def test_sasdata_hist_instance(self):
         """
-        test hist()
+        Test method hist returns a dict.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        cars.set_results('TEXT')
-        ll = cars.hist('MSRP')
-        expected = 'alt="The SGPlot Procedure" src="data:image/png;base64'
+        ll = self.cars.hist('MSRP')
+
         self.assertIsInstance(ll, dict, msg="cars.hist(...) didn't return dict")
+
+    def test_sasdata_hist_length(self):
+        """
+        Test method hist returns a listing that is long enough?
+        """
+        ll = self.cars.hist('MSRP')
+
+        # FIXME: How do we know 40,000 is an ok threshold?
         self.assertGreater(len(ll['LST']), 40000, msg="cars.hist(...) result were too short")
-        self.assertIn(expected, ll['LST'], msg="cars.hist(...) result weren't what was expected")
-        cars.set_results('HTML')
 
-    def test_SASdata_series(self):
+    def test_sasdata_hist_values(self):
         """
-        test series()
+        Test method hist returns the correct data.
         """
-        self.sas.set_batch(True)
-        ll = self.sas.submit('''proc sql; 
-                                create table sales as 
-                                select month, sum(actual) as tot_sales, sum(predict) as predicted_sales 
-                                from sashelp.prdsale 
-                                group by 1 
-                                order by month ;quit;
-                             ''')
+        EXPECTED = 'alt="The SGPlot Procedure" src="data:image/png;base64'
+
+        ll = self.cars.hist('MSRP')
+
+        self.assertIn(EXPECTED, ll['LST'], msg="cars.hist(...) result weren't what was expected")
+
+    def test_sasdata_series_instance(self):
+        """
+        Test method series returns a dict.
+        """
+        self.sas.submit(SALES_QUERY)
         sales = self.sas.sasdata('sales')
+
         ll = sales.series(y=['tot_sales', 'predicted_sales'], x='month', title='total vs. predicted sales')
-        expected = 'alt="The SGPlot Procedure" src="data:image/png;base64'
         self.assertIsInstance(ll, dict, msg="cars.series(...) didn't return dict")
+
+    def test_sasdata_series_length(self):
+        """
+        Test method series returns a listing that is long enough?
+        """
+        self.sas.submit(SALES_QUERY)
+        sales = self.sas.sasdata('sales')
+
+        # FIXME: How do we know 70,000 is an ok threshold?
+        ll = sales.series(y=['tot_sales', 'predicted_sales'], x='month', title='total vs. predicted sales')
+
         self.assertGreater(len(ll['LST']), 70000, msg="cars.series(...) result were too short")
-        self.assertIn(expected, ll['LST'], msg="cars.series(...) result weren't what was expected")
 
-    def test_SASdata_heatmap(self):
+    def test_sasdata_series_values(self):
         """
-        test heatmap()
+        Test method series returns the correct data.
         """
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.sas.set_batch(True)
-        ll = cars.heatmap('MSRP', 'horsepower')
-        expected = 'alt="The SGPlot Procedure" src="data:image/png;base64'
+        EXPECTED = 'alt="The SGPlot Procedure" src="data:image/png;base64'
+
+        self.sas.submit(SALES_QUERY)
+        sales = self.sas.sasdata('sales')
+
+        ll = sales.series(y=['tot_sales', 'predicted_sales'], x='month', title='total vs. predicted sales')
+
+        self.assertIn(EXPECTED, ll['LST'], msg="cars.series(...) result weren't what was expected")
+
+    def test_sasdata_heatmap_instance(self):
+        """
+        Test method heatmap returns a dict.
+        """
+        ll = self.cars.heatmap('MSRP', 'horsepower')
+
         self.assertIsInstance(ll, dict, msg="cars.heatmap(...) didn't return dict")
+
+    def test_sasdata_heatmap_length(self):
+        """
+        Test method heatmap returns a listing that is long enough?
+        """
+        ll = self.cars.heatmap('MSRP', 'horsepower')
+
+        # FIXME: How do we know 30,000 is an ok threshold?
         self.assertGreater(len(ll['LST']), 30000, msg="cars.heatmap(...) result were too short")
-        self.assertIn(expected, ll['LST'], msg="cars.heatmap(...) result weren't what was expected")
 
-    def test_SASdata_sort1(self):
+    def test_sasdata_heatmap_values(self):
         """
-        Create dataset in WORK
+        Test method heatmap returns the correct data.
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        # Sort data in place by one variable
+        EXPECTED = 'alt="The SGPlot Procedure" src="data:image/png;base64'
+
+        ll = self.cars.heatmap('MSRP', 'horsepower')
+
+        self.assertIn(EXPECTED, ll['LST'], msg="cars.heatmap(...) result weren't what was expected")
+
+    def test_sasdata_sort_1var(self):
+        """
+        Test method sort using one variable
+        """
+        wkcars = self.helper_wkcars()
         wkcars.sort('type')
+
+        # FIXME: This is not testing sort, only sasdata construction.
         self.assertIsInstance(wkcars, SASdata, msg="Sort didn't return SASdata Object")
 
-    def test_SASdata_sort2(self):
+    def test_sasdata_sort_2var(self):
         """
-        Create dataset in WORK
+        Test method sort using two variables
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        # Sort data in plce by multiple variables
+        wkcars = self.helper_wkcars()
         wkcars.sort('type descending origin')
+
+        # FIXME: This is not testing sort, only sasdata construction.
         self.assertIsInstance(wkcars, SASdata, msg="Sort didn't return SASdata Object")
 
-    def test_SASdata_sort3(self):
+    def test_sasdata_sort_compare_equal(self):
         """
-        Create dataset in WORK
+        Test method sort returns a sorted SASdata object
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        # create a second object pointing to the same data set
+        wkcars = self.helper_wkcars()
         dup = wkcars.sort('type')
+
+        # FIXME: This is not testing sort, as `dup` always equals `wkcars`
+        # regardless of sort order. This is because `sort()` always returns
+        # `self` if no `out=` is specified. Therefore, `dup` is a reference
+        # to the same address as `wkcars`. You can confirm this by doing the
+        # following:
+        #   >>> id(wkcars)
+        #   >>> id(dup)
+        #
+        # Effectively, this test is doing the following:
+        #   >>> wkcars = 'Whatever'
+        #   >>> dup = wkcars
+        #   >>> wkcars == dup   # True, because dup points to wkcars
         self.assertEqual(wkcars, dup, msg="Sort objects are not equal but should be")
 
-    def test_SASdata_sort4(self):
+    def test_sasdata_sort_compare_notequal(self):
         """
-        Create dataset in WORK
+        Test method sort with out= returns a copy sorted differently than
+        the source.
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        # create a second object with a different sort order
+        wkcars = self.helper_wkcars()
         diff = self.sas.sasdata('diff')
-        diff = wkcars.sort('origin', diff)
+        diff = wkcars.sort('origin', out=diff)
+
         self.assertNotEqual(wkcars, diff, msg="Sort objects are equal but should not be")
 
-    def test_SASdata_sort5(self):
+    def test_sasdata_sort_out(self):
         """
-        Create dataset in WORK
+        Test method sort with out= returns a new SASdata object.
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        # create object within call
+        wkcars = self.helper_wkcars()
         wkcars.sort('type')
         out1 = wkcars.sort('origin', self.sas.sasdata('out1'))
+
         self.assertIsInstance(out1, SASdata, msg="Sort didn't return new SASdata Object")
-        self.assertNotEqual(wkcars, out1, msg="Sort objects are equal but should not be")
 
-    def test_SASdata_sort6(self):
+    def test_sasdata_sort_invalidcol(self):
         """
-        Create dataset in WORK
+        Test method sort raises a RuntimError if provided an invalid column.
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        # sort by missing variable
-        self.assertRaises(RuntimeError, lambda: wkcars.sort('foobar'))
+        wkcars = self.helper_wkcars()
 
-    def test_SASdata_score1(self):
+        with self.assertRaises(RuntimeError):
+            wkcars.sort('foobar')
+
+    def test_sasdata_score_columninfo(self):
         """
-        Create dataset in WORK
+        Test method score adds a new column.
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        a = wkcars.columnInfo()
+        wkcars = self.helper_wkcars()
+        original = wkcars.columnInfo()
+
         wkcars.score(code='P_originUSA = origin;')
-        b = wkcars.columnInfo()
-        self.assertNotEqual(a, b, msg="B should have an extra column P_originUSA")
+        w_newcol = wkcars.columnInfo()
 
-    def test_SASdata_score2(self):
+        self.assertNotEqual(original, w_newcol, msg="B should have an extra column P_originUSA")
+
+    def test_sasdata_score_out_source(self):
         """
-        Create dataset in WORK
+        Test method score does not modify the original table when out= is
+        specified.
         """
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        wkcars.set_results('PANDAS')
+        wkcars = self.helper_wkcars()
+        wkcars.set_results('pandas')
+
         wkcars2 = self.sas.sasdata('cars2', 'work')
-        wkcars2.set_results('PANDAS')
+        wkcars2.set_results('pandas')
+
         a = wkcars.columnInfo()
         wkcars.score(code='P_originUSA = origin;', out=wkcars2)
         b = wkcars.columnInfo()
+
         self.assertFalse(assert_frame_equal(a, b), msg="B should be identical to a")
+
+    def test_sasdata_score_out_copy(self):
+        """
+        Test method score writes to a new table if out= is specified.
+        """
+        wkcars = self.helper_wkcars()
+        wkcars.set_results('pandas')
+
+        wkcars2 = self.sas.sasdata('cars2', 'work')
+        wkcars2.set_results('pandas')
+
+        wkcars.score(code='P_originUSA = origin;', out=wkcars2)
+
+        # FIXME: Always passes because sasdate returns a SASdata object on
+        # construction. Need to check that wkcars2 actually contains data.
         self.assertIsInstance(wkcars2, SASdata, "Does out dataset exist")
 
-    def test_SASdata_score3(self):
+    def test_sasdata_score_file_out(self):
+        """
+        Test method score accepts a file path as input and uses the contents
+        to generate score columns. If out= is specified write to a different
+        table.
+        """
         with TemporaryDirectory() as temppath:
             with open(os.path.join(temppath, 'score.sas'), 'w') as f:
                 f.write('P_originUSA = origin;')
-        # Create dataset in WORK
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
-        wkcars.set_results('PANDAS')
+
+        wkcars = self.helper_wkcars()
+        wkcars.set_results('pandas')
+
         wkcars2 = self.sas.sasdata('cars2', 'work')
-        wkcars2.set_results('PANDAS')
+        wkcars2.set_results('pandas')
+
         a = wkcars.columnInfo()
         wkcars.score(file=f.name, out=wkcars2)
         b = wkcars.columnInfo()
-        self.assertFalse(assert_frame_equal(a, b), msg="B should be identical to a")
-        self.assertIsInstance(wkcars2, SASdata, "Does out dataset exist")
 
-    def test_SASdata_score4(self):
+        self.assertFalse(assert_frame_equal(a, b), msg="B should be identical to a")
+
+    def test_sasdata_score_file(self):
+        """
+        Test method score accepts a file path as input and uses the contents
+        to generate score columns.
+        """
         with TemporaryDirectory() as temppath:
             with open(os.path.join(temppath, 'score.sas'), 'w') as f:
                 f.write('P_originUSA = origin;')
-        # Create dataset in WORK
-        self.sas.submit("data cars; set sashelp.cars; id=_n_;run;")
-        wkcars = self.sas.sasdata('cars')
+
+        wkcars = self.helper_wkcars()
+
         a = wkcars.columnInfo()
         wkcars.score(file=f.name)
         b = wkcars.columnInfo()
+
         self.assertNotEqual(a, b, msg="B should have an extra column P_originUSA")
 
     def test_regScoreAssess(self):
+        # FIXME: Consider moving to test_sasstat.py
         stat = self.sas.sasstat()
-        self.sas.submit("""
-        data work.class;
-            set sashelp.class;
-        run;
-        """)
-        tr = self.sas.sasdata("class", "work")
-        tr.set_results('PANDAS')
+        tr = self.helper_wkclass()
+        tr.set_results('pandas')
+
         with TemporaryDirectory() as temppath:
             fname = os.path.join(temppath, 'hpreg_code.sas')
             b = stat.hpreg(data=tr, model='weight=height', code=fname)
             tr.score(file=os.path.join(temppath, 'hpreg_code.sas'))
+
             # check that p_weight is in columnInfo
+            # FIXME: Only assert once
             self.assertTrue('P_Weight' in tr.columnInfo()['Variable'].values, msg="Prediction Column not found")
 
         res1 = tr.assessModel(target='weight', prediction='P_weight', nominal=False)
@@ -323,21 +480,20 @@ class TestSASdataObject(unittest.TestCase):
         self.assertIsInstance(res1, SASresults, "Is return type correct")
 
     def test_regScoreAssess2(self):
+        # FIXME: Consider moving to test_sasstat.py
         stat = self.sas.sasstat()
-        self.sas.submit("""
-        data work.class;
-            set sashelp.class;
-        run;
-        """)
-        tr = self.sas.sasdata("class", "work")
-        tr.set_results('PANDAS')
+        tr = self.helper_wkclass()
+        tr.set_results('pandas')
+
         with TemporaryDirectory() as temppath:
             fname = os.path.join(temppath, 'hplogistic_code.sas')
             b = stat.hplogistic(data=tr, cls= 'sex', model='sex = weight height', code=fname)
             # This also works with hardcoded strings
             # b = stat.hplogistic(data=tr, cls='sex', model='sex = weight height', code=r'c:\public\foo.sas')
             tr.score(file=fname)
+
             # check that P_SexF is in columnInfo
+            # FIXME: Only assert once
             self.assertTrue('P_SexF' in tr.columnInfo()['Variable'].values, msg="Prediction Column not found")
 
         res1 = tr.assessModel(target='sex', prediction='P_SexF', nominal=True, event='F')
@@ -347,54 +503,59 @@ class TestSASdataObject(unittest.TestCase):
                              str(a), str(b)))
         self.assertIsInstance(res1, SASresults, "Is return type correct")
 
-    def test_partition1(self):
-        self.sas.submit("""
-                data work.class;
-                    set sashelp.class;
-                run;
-                """)
-        tr = self.sas.sasdata("class", "work")
-        tr.set_results('PANDAS')
+    def test_partition_partind(self):
+        """
+        TODO: Add documentation
+        """
+        tr = self.helper_wkclass()
+        tr.set_results('pandas')
+
         tr.partition(var='sex', fraction=.5, kfold=1, out=None, singleOut=True)
+
         self.assertTrue('_PartInd_' in tr.columnInfo()['Variable'].values, msg="Partition Column not found")
 
-    def test_partition2(self):
-        self.sas.submit("""
-                data work.class;
-                    set sashelp.class;
-                run;
-                """)
-        tr = self.sas.sasdata("class", "work")
-        tr.set_results('PANDAS')
+    def test_partition_cvfold2(self):
+        """
+        TODO: Add documentation
+        """
+        tr = self.helper_wkclass()
+        tr.set_results('pandas')
+
         tr.partition(var='sex', fraction=.5, kfold=2, out=None, singleOut=True)
+
         self.assertTrue('_cvfold2' in tr.columnInfo()['Variable'].values, msg="Partition Column not found")
 
-    def test_partition3(self):
-        self.sas.submit("""
-                data work.class;
-                    set sashelp.class;
-                run;
-                """)
+    def test_partition_out(self):
+        """
+        TODO: Add documentation
+        """
+        tr = self.helper_wkclass()
         tr = self.sas.sasdata("class", "work")
+        tr.set_results('pandas')
+
         out = self.sas.sasdata("class2", "work")
-        tr.set_results('PANDAS')
-        out.set_results('PANDAS')
+        out.set_results('pandas')
+
         tr.partition(var='sex', fraction=.5, kfold=2, out=out, singleOut=True)
+
+        # FIXME: Only assert once
         self.assertFalse('_cvfold1' in tr.columnInfo()['Variable'].values, msg="Writing to wrong table")
         self.assertFalse('_PartInd_ ' in tr.columnInfo()['Variable'].values, msg="Writing to wrong table")
         self.assertTrue('_cvfold2' in out.columnInfo()['Variable'].values, msg="Partition Column not found")
 
-    def test_partition4(self):
-        self.sas.submit("""
-                data work.class;
-                    set sashelp.class;
-                run;
-                """)
-        tr = self.sas.sasdata("class", "work")
-        out = self.sas.sasdata("class2", "work")
+    def test_partition_out2(self):
+        """
+        TODO: Add documentation
+        """
+        tr = self.helper_wkclass()
         tr.set_results('PANDAS')
+
+        out = self.sas.sasdata("class2", "work")
         out.set_results('PANDAS')
+
         res1 = tr.partition(var='sex', fraction=.5, kfold=2, out=out, singleOut=False)
+
+        # FIXME: Only assert once
         self.assertFalse('_cvfold1' in tr.columnInfo()['Variable'].values, msg="Writing to wrong table")
         self.assertFalse('_PartInd_ ' in tr.columnInfo()['Variable'].values, msg="Writing to wrong table")
         self.assertTrue('_cvfold2' in out.columnInfo()['Variable'].values, msg="Partition Column not found")
@@ -402,36 +563,52 @@ class TestSASdataObject(unittest.TestCase):
         self.assertIsInstance(res1[0], tuple, "Is return type correct")
         self.assertIsInstance(res1[0][1], SASdata, "Is return type correct")
 
-    def test_partition5(self):
-        self.sas.submit("""
-                data work.class;
-                    set sashelp.class;
-                run;
-                """)
-        tr = self.sas.sasdata("class", "work")
-        tr.set_results('PANDAS')
+    def test_partition_partind_novar(self):
+        """
+        TODO: Add documentation
+        """
+        tr = self.helper_wkclass()
+        tr.set_results('pandas')
         tr.partition(fraction=.5, kfold=1, out=None, singleOut=True)
+
         self.assertTrue('_PartInd_' in tr.columnInfo()['Variable'].values, msg="Partition Column not found")
 
-    def test_info1(self):
+    def test_info_pandas_instance(self):
+        """
+        Test method info works with pandas result type.
+        """
         tr = self.sas.sasdata("class", "sashelp")
-        tr.set_results('Pandas')
+        tr.set_results('pandas')
         res = tr.info()
+
         self.assertIsInstance(res, pd.DataFrame, msg='Data frame not returned')
+
+    def test_info_pandas_shape(self):
+        """
+        Test method info works with pandas result type.
+        """
+        tr = self.sas.sasdata("class", "sashelp")
+        tr.set_results('pandas')
+        res = tr.info()
+
         self.assertEqual(res.shape, (5, 4), msg="wrong shape returned")
 
-    def test_info2(self):
+    def test_info_text(self):
+        """
+        Test method info does not work with text result type.
+        """
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('text')
         res = tr.info()
+
         self.assertIsNone(res, msg="only works with Pandas")
 
-    def test_info3(self):
+    def test_info_html(self):
+        """
+        Test method info does not work with html result type.
+        """
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('html')
         res = tr.info()
+
         self.assertIsNone(res, msg="only works with Pandas")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/saspy/tests/test_sassession.py
+++ b/saspy/tests/test_sassession.py
@@ -7,25 +7,32 @@ class TestSASsessionObject(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.sas = saspy.SASsession()
+        cls.sas.set_batch(True)
 
     @classmethod
     def tearDownClass(cls):
-        if cls.sas:
-           cls.sas._endsas()
+        cls.sas._endsas()
 
+    def test_sassession(self):
+        self.assertIsInstance(self.sas, saspy.SASsession)
 
-    def test_SASsession(self):
-        self.assertIsInstance(self.sas, saspy.SASsession, msg="sas = saspy.SASsession(...) failed")
-
-    def test_SASsession_exist(self):
-        #test exist true
+    def test_sassession_exist_true(self):
+        """
+        Test method exist returns True for a dataset that exists
+        """
         exists = self.sas.exist('cars', libref='sashelp')
-        self.assertTrue(exists, msg="exists = self.sas.exist(...) failed")
+        self.assertTrue(exists)
 
-        #test exist false
+    def test_sassession_exist_false(self):
+        """
+        Test method exist returns False for a dataset that does not exist
+        """
         exists = self.sas.exist('notable', libref='sashelp')
-        self.assertFalse(exists, msg="exists = self.sas.exist(...) failed")
+        self.assertFalse(exists)
 
+    # FIXME
+    # Test should be done in test_sasdata.py
+    '''
     def test_SASsession_sasdata(self):
         #test sasdata existing
         cars = self.sas.sasdata('cars', libref='sashelp', results='text')
@@ -39,63 +46,97 @@ class TestSASsessionObject(unittest.TestCase):
         ll = self.sas.submit("data notable;x=1;run;")
         exists = self.sas.exist('notable')
         self.assertTrue(exists, msg="exists = self.sas.exist(...) failed")
+    '''
 
-    def test_SASsession_csv(self):
-        # test write and read csv
+    def test_SASsession_csv_read(self):
+        """
+        Test method read_csv properly imports a csv file
+        """
+        EXPECTED = ['1', 'Acura', 'MDX', 'SUV', 'Asia', 'All', '$36,945', '$33,337', '3.5']
 
-        self.sas.set_batch(True)
+        with TemporaryDirectory() as temppath:
+            fname = os.path.join(temppath, 'sas_csv_test.csv')
+            self.sas.write_csv(fname, 'cars', libref='sashelp')
+
+            csvdata = self.sas.read_csv(fname, 'csvcars', results='text')
+
+        ll = csvdata.head()
+
+        rows = ll['LST'].splitlines()
+        retrieved = [x.split() for x in rows]
+
+        self.assertIn(EXPECTED, retrieved, msg="csvcars.head() result didn't contain row 1")
+
+    def test_sassession_csv_write(self):
+        """
+        Test method write_csv properly exports a csv file
+        """
         with TemporaryDirectory() as temppath:
             fname = os.path.join(temppath, 'sas_csv_test.csv')
             log = self.sas.write_csv(fname, 'cars', libref='sashelp')
-            self.assertNotIn("ERROR", log, msg="sas.write_csv() failed")
-            csvdata = self.sas.read_csv(fname, 'csvcars', results='text')
-            ll = csvdata.head()
-        expected = ['1', 'Acura', 'MDX', 'SUV', 'Asia', 'All', '$36,945', '$33,337', '3.5']
-        rows = ll['LST'].splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-           retrieved.append(rows[i].split()[:9])
-        self.assertIn(expected, retrieved, msg="csvcars.head() result didn't contain row 1")
-        
-    def test_SASsession_datasets(self):
-        # test datasets()
-        self.sas.set_batch(True)
+
+        self.assertNotIn("ERROR", log, msg="sas.write_csv() failed")
+
+    def test_sassession_datasets_work(self):
+        """
+        Test method datasets can identify that the WORK library exists
+        """
+        EXPECTED = ['Libref', 'WORK']
+
         log = self.sas.datasets()
-        expected = ['Libref', 'WORK']
         rows = log.splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-           retrieved.append(rows[i].split())
-        self.assertIn(expected, retrieved, msg="cars.datasets() result didn't contain expected result")
+        retrieved = [x.split() for x in rows]
+
+        self.assertIn(EXPECTED, retrieved)
+
+    def test_sassession_datasets_sashelp(self):
+        """
+        Test method datasets can identify that the SASHELP library exists
+        """
+        EXPECTED = ['Libref', 'SASHELP']
 
         log = self.sas.datasets('sashelp')
-        expected = ['Libref', 'SASHELP']
         rows = log.splitlines()
-        retrieved = []
-        for i in range(len(rows)):
-           retrieved.append(rows[i].split())
-           if i > 20:
-              break  # it'll be in the first 20 rows for sure. don't need all of it
-        self.assertIn(expected, retrieved, msg="cars.datasets(...) result didn't contain expected result")
-        
-    def test_SASsession_procobjs(self):
-        # test stat
+        retrieved = [x.split() for x in rows]
+
+        self.assertIn(EXPECTED, retrieved)
+
+    def test_sassession_hasstat(self):
+        """
+        Test method sasstat() returns a SASstat object.
+        """
         stat = self.sas.sasstat()
+
         self.assertIsInstance(stat, saspy.sasstat.SASstat, msg="stat = self.sas.sasstat() failed")
 
-        # test ets
+    def test_sassession_hasets(self):
+        """
+        Test method sasets() returns a SASets object.
+        """
         ets = self.sas.sasets()
+
         self.assertIsInstance(ets, saspy.sasets.SASets, msg="ets = self.sas.sasets() failed")
 
-        # test qc
+    def test_sassession_hasqc(self):
+        """
+        Test method sasqc() returns a SASqc object.
+        """
         qc = self.sas.sasqc()
+
         self.assertIsInstance(qc, saspy.sasqc.SASqc, msg="qc = self.sas.sasqc() failed")
 
-        # test ml
+    def test_sassession_hasml(self):
+        """
+        Test method sasml() returns a SASml object.
+        """
         ml = self.sas.sasml()
+
         self.assertIsInstance(ml, saspy.sasml.SASml, msg="ml = self.sas.sasml() failed")
 
-        # test util
+    def test_sassession_hasutil(self):
+        """
+        Test method sasutil() returns a SASutil object.
+        """
         util = self.sas.sasutil()
-        self.assertIsInstance(util, saspy.sasutil.SASutil, msg="util = self.sas.sasutil() failed")
 
+        self.assertIsInstance(util, saspy.sasutil.SASutil, msg="util = self.sas.sasutil() failed")

--- a/saspy/tests/test_sassession.py
+++ b/saspy/tests/test_sassession.py
@@ -30,24 +30,6 @@ class TestSASsessionObject(unittest.TestCase):
         exists = self.sas.exist('notable', libref='sashelp')
         self.assertFalse(exists)
 
-    # FIXME
-    # Test should be done in test_sasdata.py
-    '''
-    def test_SASsession_sasdata(self):
-        #test sasdata existing
-        cars = self.sas.sasdata('cars', libref='sashelp', results='text')
-        self.assertIsInstance(cars, saspy.SASdata, msg="cars = sas.sasdata(...) failed")
-
-        #test sasdata not existing
-        notable = self.sas.sasdata('notable', results='text')
-        self.assertIsInstance(notable, saspy.SASdata, msg="cars = sas.sasdata(...) failed")
-
-        #test create non-existing table
-        ll = self.sas.submit("data notable;x=1;run;")
-        exists = self.sas.exist('notable')
-        self.assertTrue(exists, msg="exists = self.sas.exist(...) failed")
-    '''
-
     def test_SASsession_csv_read(self):
         """
         Test method read_csv properly imports a csv file


### PR DESCRIPTION
Refactor some unit tests and note places that need additional revisions in the future.

Major changes include renaming tests to be more descriptive of their purpose, isolating asserts so that only one occurs per test, and moving some repeated Python/SAS code to a function or variable to improve readability or performance.

### `test_pandas.py`
* Updated `TestPandasDataFrameIntegration` to only `assert` once per test.
* Updated test case to store `test_data` `SASdata` object as attribute for frequent access.
* Added light documentation.
* Renamed test functions to indicate purpose.
* Marked potential revisions with `FIXME`.

### `test_sassession.py`
* Updated `TestSASsessionObject` to only `assert` once per test.
* Added light documentation.
* Renamed test functions to indicate purpose.
* Moved some tests to other modules.

### `test_sasdata.py`
* Updated `TestSASdataObject` to only `assert` once per test for many tests. Some changes remain outstanding.
* Updated test case to store `cars` `SASdata` object as attribute for frequent access.
* Added light documentation.
* Added helper functions to reduce code repetition.
* Renamed test functions to indicate purpose where applicable.
* Moved some tests in from other modules.
* Marked potential revisions with `FIXME` or `TODO`.