### PR TITLE
Add support for ~/.authinfo to IOMCOM

### DIFF
--- a/saspy/sascfg.py
+++ b/saspy/sascfg.py
@@ -211,6 +211,7 @@ winiomIWA  = {'java'    : 'java',
 #                 session encoding of the IOM server.
 #   omruser     - SAS user. This option is ignored on local connections.
 #   omrpw       - SAS password. This option is ignored on local connections.
+#   authkey     - Identifier for credentials to read from .authinfo file.
 
 iomcom = {
     'iomhost': 'mynode.mycompany.org',

--- a/saspy/sasexceptions.py
+++ b/saspy/sasexceptions.py
@@ -36,11 +36,3 @@ class SASIONotSupportedError(Exception):
             alt_text = ''
 
         return 'Cannot use {} I/O module on Windows. {}'.format(self.method, alt_text)
-
-
-class SASAuthenticationError(Exception):
-    def __init__(self, message: str):
-        self.message = message
-
-    def __str__(self):
-        return message

--- a/saspy/sasexceptions.py
+++ b/saspy/sasexceptions.py
@@ -36,3 +36,11 @@ class SASIONotSupportedError(Exception):
             alt_text = ''
 
         return 'Cannot use {} I/O module on Windows. {}'.format(self.method, alt_text)
+
+
+class SASAuthenticationError(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+    def __str__(self):
+        return message

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -89,7 +89,7 @@ class SASConfigCOM(object):
         try:
             with open(authfile, 'r') as f:
                 # Take first matching line found
-                parsed = (shlex.split(x) for x in f.readlines())
+                parsed = (shlex.split(x, posix=False) for x in f.readlines())
                 authline = next(filter(lambda x: x[0] == self.authkey, parsed), None)
 
         except OSError:


### PR DESCRIPTION

The Java IOM access method supports reading username/password credentials from a ~/.authinfo file.  The spec for this file can be found here: https://documentation.sas.com/api/docsets/authinfo/9.4/content/authinfo.pdf.

This file uses the following format:
```
AUTHKEY username USERNAME password PASSWORD
```

Where the user can define the `AUTHKEY`, `USERNAME`, and `PASSWORD` attributes.

This PR was spawned from a comment in issue #237 