### PR TITLE
Newlines

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -871,7 +871,8 @@ class SASsession():
         return log
      
     def df2sd(self, df: 'pd.DataFrame', table: str = '_df', libref: str = '',
-              results: str = '', keep_outer_quotes: bool = False) -> 'SASdata':
+              results: str = '', keep_outer_quotes: bool = False,
+                                 embedded_newlines: bool = False) -> 'SASdata':
         """
         This is an alias for 'dataframe2sasdata'. Why type all that?
 
@@ -882,10 +883,11 @@ class SASsession():
         :param keep_outer_quotes: the defualt is for SAS to strip outer quotes from delimitted data. This lets you keep them
         :return: SASdata object
         """
-        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes)
+        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines)
 
     def dataframe2sasdata(self, df: 'pd.DataFrame', table: str = '_df', libref: str = '',
-                          results: str = '', keep_outer_quotes: bool = False) -> 'SASdata':
+                          results: str = '', keep_outer_quotes: bool = False,
+                                             embedded_newlines: bool = False) -> 'SASdata':
         """
         This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
 
@@ -910,7 +912,7 @@ class SASsession():
             print("too complicated to show the code, read the source :), sorry.")
             return None
         else:
-            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes)
+            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines)
 
         if self.exist(table, libref):
             return SASdata(self, libref, table, results)

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -872,7 +872,8 @@ class SASsession():
      
     def df2sd(self, df: 'pd.DataFrame', table: str = '_df', libref: str = '',
               results: str = '', keep_outer_quotes: bool = False,
-                                 embedded_newlines: bool = False) -> 'SASdata':
+                                 embedded_newlines: bool = False, 
+              LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03') -> 'SASdata':
         """
         This is an alias for 'dataframe2sasdata'. Why type all that?
 
@@ -881,13 +882,18 @@ class SASsession():
         :param libref: the libref for the SAS Data Set being created. Defaults to WORK, or USER if assigned
         :param results: format of results, SASsession.results is default, PANDAS, HTML or TEXT are the alternatives
         :param keep_outer_quotes: the defualt is for SAS to strip outer quotes from delimitted data. This lets you keep them
+        :param embedded_newlines: if any char columns have embedded CR or LF, set this to True to get them iported into the SAS data set
+        :param LF: if embedded_newlines=True, the cheacter to use for LF when transferring the data; defaults to '\x01'
+        :param CR: if embedded_newlines=True, the cheacter to use for CR when transferring the data; defaults to '\x02'
+        :param colsep: the column seperator chatracter used for streaming the delimmited data to SAS defaults to '\x03'
         :return: SASdata object
         """
-        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines)
+        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines, LF, CR, colsep)
 
     def dataframe2sasdata(self, df: 'pd.DataFrame', table: str = '_df', libref: str = '',
                           results: str = '', keep_outer_quotes: bool = False,
-                                             embedded_newlines: bool = False) -> 'SASdata':
+                                             embedded_newlines: bool = False,
+                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03') -> 'SASdata':
         """
         This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
 
@@ -896,6 +902,10 @@ class SASsession():
         :param libref: the libref for the SAS Data Set being created. Defaults to WORK, or USER if assigned
         :param results: format of results, SASsession.results is default, PANDAS, HTML or TEXT are the alternatives
         :param keep_outer_quotes: the defualt is for SAS to strip outer quotes from delimitted data. This lets you keep them
+        :param embedded_newlines: if any char columns have embedded CR or LF, set this to True to get them iported into the SAS data set
+        :param LF: if embedded_newlines=True, the cheacter to use for LF when transferring the data; defaults to '\x01'
+        :param CR: if embedded_newlines=True, the cheacter to use for CR when transferring the data; defaults to '\x02'
+        :param colsep: the column seperator chatracter used for streaming the delimmited data to SAS defaults to '\x03'
         :return: SASdata object
         """
         if self.sascfg.pandas:
@@ -912,7 +922,7 @@ class SASsession():
             print("too complicated to show the code, read the source :), sorry.")
             return None
         else:
-            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines)
+            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines, LF, CR, colsep)
 
         if self.exist(table, libref):
             return SASdata(self, libref, table, results)

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1011,13 +1011,18 @@ class SASsessionHTTP():
 
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
                          libref: str ="", keep_outer_quotes: bool=False,
-                                          embedded_newlines: bool=False):
+                                          embedded_newlines: bool=False,
+                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03'):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
       table   - the name of the SAS Data Set to create
       libref  - the libref for the SAS Data Set being created. Defaults to WORK, or USER if assigned
       keep_outer_quotes - for character columns, have SAS keep any outer quotes instead of stripping them off.
+      embedded_newlines - if any char columns have embedded CR or LF, set this to True to get them iported into the SAS data set
+      LF - if embedded_newlines=True, the cheacter to use for LF when transferring the data; defaults to '\x01'
+      CR - if embedded_newlines=True, the cheacter to use for CR when transferring the data; defaults to '\x02'
+      colsep - the column seperator chatracter used for streaming the delimmited data to SAS defaults to '\x03'
       '''
       input  = ""
       xlate  = ""
@@ -1026,6 +1031,9 @@ class SASsessionHTTP():
       length = ""
       dts    = []
       ncols  = len(df.columns)
+      lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
+      cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
+      delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
 
       for name in range(ncols):
          input += "'"+str(df.columns[name])+"'n "
@@ -1043,8 +1051,8 @@ class SASsessionHTTP():
                input  += "~ "
             dts.append('C')
             if embedded_newlines:
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, '01'x);\n "
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, '02'x);\n "
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, "+lf+");\n "
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, "+cr+");\n "
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
                length += " '"+str(df.columns[name])+"'n 8"
@@ -1066,7 +1074,7 @@ class SASsessionHTTP():
          code += "length "+length+";\n"
       if len(format):
          code += "format "+format+";\n"
-      code += "infile datalines delimiter='03'x DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
+      code += "infile datalines delimiter="+delim+" DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
       self._asubmit(code, "text")
 
       code = ""
@@ -1082,7 +1090,7 @@ class SASsessionHTTP():
                   var = ' '
                else:
                   if embedded_newlines:
-                     var = var.replace('\n', chr(1)).replace('\r', chr(2))
+                     var = var.replace('\n', LF).replace('\r', CR)
             elif dts[col] == 'B':
                var = str(int(row[col]))
             elif dts[col] == 'D':
@@ -1093,7 +1101,7 @@ class SASsessionHTTP():
 
             card += var
             if col < (ncols-1):
-               card += chr(3)
+               card += colsep
          code += card+"\n"
          if len(code) > 4000:
             self._asubmit(code, "text")

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1010,7 +1010,8 @@ class SASsessionHTTP():
       return len(x.encode(self.sascfg.encoding))
 
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
-                         libref: str ="", keep_outer_quotes: bool=False):
+                         libref: str ="", keep_outer_quotes: bool=False,
+                                          embedded_newlines: bool=False):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1019,6 +1020,7 @@ class SASsessionHTTP():
       keep_outer_quotes - for character columns, have SAS keep any outer quotes instead of stripping them off.
       '''
       input  = ""
+      xlate  = ""
       card   = ""
       format = ""
       length = ""
@@ -1040,6 +1042,9 @@ class SASsessionHTTP():
             if keep_outer_quotes:
                input  += "~ "
             dts.append('C')
+            if embedded_newlines:
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, '01'x);\n "
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, '02'x);\n "
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
                length += " '"+str(df.columns[name])+"'n 8"
@@ -1061,7 +1066,7 @@ class SASsessionHTTP():
          code += "length "+length+";\n"
       if len(format):
          code += "format "+format+";\n"
-      code += "infile datalines delimiter='03'x DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\ndatalines4;"
+      code += "infile datalines delimiter='03'x DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
       self._asubmit(code, "text")
 
       code = ""
@@ -1072,8 +1077,12 @@ class SASsessionHTTP():
 
             if   dts[col] == 'N' and var == 'nan':
                var = '.'
-            elif dts[col] == 'C' and var == 'nan':
-               var = ' '
+            elif dts[col] == 'C':
+               if var == 'nan':
+                  var = ' '
+               else:
+                  if embedded_newlines:
+                     var = var.replace('\n', chr(1)).replace('\r', chr(2))
             elif dts[col] == 'B':
                var = str(int(row[col]))
             elif dts[col] == 'D':

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1383,7 +1383,8 @@ Will use HTML5 for this SASsession.""")
       return len(x.encode(self.sascfg.encoding))
 
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
-                         libref: str ="", keep_outer_quotes: bool=False):
+                         libref: str ="", keep_outer_quotes: bool=False,
+                                          embedded_newlines: bool=False):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1392,6 +1393,7 @@ Will use HTML5 for this SASsession.""")
       keep_outer_quotes - for character columns, have SAS keep any outer quotes instead of stripping them off.
       """
       input  = ""
+      xlate  = ""
       card   = ""
       format = ""
       length = ""
@@ -1413,6 +1415,9 @@ Will use HTML5 for this SASsession.""")
             if keep_outer_quotes:
                input  += "~ "
             dts.append('C')
+            if embedded_newlines:
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, '01'x);\n "
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, '02'x);\n "
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
                length += " '"+str(df.columns[name])+"'n 8"
@@ -1434,7 +1439,7 @@ Will use HTML5 for this SASsession.""")
          code += "length "+length+";\n"
       if len(format):
          code += "format "+format+";\n"
-      code += "infile datalines delimiter='03'x DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\ndatalines4;"
+      code += "infile datalines delimiter='03'x DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
       self._asubmit(code, "text")
 
       code = ""
@@ -1445,8 +1450,12 @@ Will use HTML5 for this SASsession.""")
 
             if   dts[col] == 'N' and var == 'nan':
                var = '.'
-            elif dts[col] == 'C' and var == 'nan':
-               var = ' '
+            elif dts[col] == 'C':
+               if var == 'nan':
+                  var = ' '
+               else:
+                  if embedded_newlines:
+                     var = var.replace('\n', chr(1)).replace('\r', chr(2))
             elif dts[col] == 'B':
                var = str(int(row[col]))
             elif dts[col] == 'D':

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1384,13 +1384,18 @@ Will use HTML5 for this SASsession.""")
 
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
                          libref: str ="", keep_outer_quotes: bool=False,
-                                          embedded_newlines: bool=False):
+                                          embedded_newlines: bool=False,
+                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03'):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
       table   - the name of the SAS Data Set to create
       libref  - the libref for the SAS Data Set being created. Defaults to WORK, or USER if assigned
       keep_outer_quotes - for character columns, have SAS keep any outer quotes instead of stripping them off.
+      embedded_newlines - if any char columns have embedded CR or LF, set this to True to get them iported into the SAS data set
+      LF - if embedded_newlines=True, the cheacter to use for LF when transferring the data; defaults to '\x01'
+      CR - if embedded_newlines=True, the cheacter to use for CR when transferring the data; defaults to '\x02'
+      colsep - the column seperator chatracter used for streaming the delimmited data to SAS defaults to '\x03'
       """
       input  = ""
       xlate  = ""
@@ -1399,6 +1404,9 @@ Will use HTML5 for this SASsession.""")
       length = ""
       dts    = []
       ncols  = len(df.columns)
+      lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
+      cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
+      delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
 
       for name in range(ncols):
          input += "'"+str(df.columns[name])+"'n "
@@ -1416,8 +1424,8 @@ Will use HTML5 for this SASsession.""")
                input  += "~ "
             dts.append('C')
             if embedded_newlines:
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, '01'x);\n "
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, '02'x);\n "
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, "+lf+");\n "
+               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, "+cr+");\n "
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
                length += " '"+str(df.columns[name])+"'n 8"
@@ -1439,7 +1447,7 @@ Will use HTML5 for this SASsession.""")
          code += "length "+length+";\n"
       if len(format):
          code += "format "+format+";\n"
-      code += "infile datalines delimiter='03'x DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
+      code += "infile datalines delimiter="+delim+" DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
       self._asubmit(code, "text")
 
       code = ""
@@ -1455,7 +1463,7 @@ Will use HTML5 for this SASsession.""")
                   var = ' '
                else:
                   if embedded_newlines:
-                     var = var.replace('\n', chr(1)).replace('\r', chr(2))
+                     var = var.replace('\n', LF).replace('\r', CR)
             elif dts[col] == 'B':
                var = str(int(row[col]))
             elif dts[col] == 'D':
@@ -1466,7 +1474,7 @@ Will use HTML5 for this SASsession.""")
 
             card += var
             if col < (ncols-1):
-               card += chr(3)
+               card += colsep
          code += card+"\n"
          if len(code) > 4000:
             self._asubmit(code, "text")
@@ -1481,8 +1489,8 @@ Will use HTML5 for this SASsession.""")
       This method exports the SAS Data Set to a Pandas Data Frame, returning the Data Frame object.
       table   - the name of the SAS Data Set you want to export to a Pandas Data Frame
       libref  - the libref for the SAS Data Set.
-      rowsep  - the row seperator character to use; defaults to '\n'
-      colsep  - the column seperator character to use; defaults to '\t'
+      rowsep  - the row seperator character to use; defaults to '\x01'
+      colsep  - the column seperator character to use; defaults to '\x02'
       """
       dsopts = dsopts if dsopts is not None else {}
 


### PR DESCRIPTION
The df2sd() method streams data from the data frame over to SAS to output into a SAS Data Set via STDIN and the datalines statement of a data step (in most access methods). This is all great except for when a char columns contains embedded newline characters (LF and/or CR). These characters always are considered the next input line by the data step. TERMSTR= is an option that can be used to change this default character, but on;y for file descriptors other than STDIN (socket or disk access methods, ...). So, to support this, I've added the ability to convert LF and CR to other values (x01 and x02 by default) before streaming them over, so SAS doesn't get tripped up parsing, and in the datastep (after being read) convert them back so they are stored. as was. in the data set. I've also added support to be able to override the default values, just in case that's ever needed. Shouldn't be for actual character data.
Tom