### PR TITLE
Nliteral

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -1283,27 +1283,6 @@ class SASsession():
                             optstr += 'NO; '
         return optstr
 
-    def _tablepath(self, table: str, libref: str=None) -> str:
-        """
-        Define a sas dataset path based on a table name and optional libref
-        name. Will return a two-level or one-level path string based on the
-        provided arguments. One-level names are of this form: `table`, while
-        two-level names are of this form: `libref.table`. If libref is not
-        defined, SAS will implicitly define the library to WORK or USER. The
-        USER library needs to have been defined previously in SAS, otherwise
-        WORK is the default option. If the `libref` parameter is any value
-        that evaluates to `False`, the one-level path is returned.
-        :param table [str]: SAS data set name.
-        :option libref [str]: Optional library name.
-        :return [str]:
-        """
-        if not libref:
-            path = table
-        else:
-            path = '{}.{}'.format(libref, table)
-
-        return path
-
     def symput(self, name, value):
         """
         :param name:  name of the macro varable to set:

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -1691,9 +1691,9 @@ class SASsession():
           code += " payment="+str(payment)
           vars += 1
        if out is not None:
-          code += " out="+out.libref + '.' + out.table + out._dsopts() 
+          code += " out="+out.libref + ".'" + out.table +"'n " + out._dsopts() 
        if out_summary is not None:
-          code += " outsum="+out_summary.libref + '.' + out_summary.table + out_summary._dsopts() 
+          code += " outsum="+out_summary.libref + ".'" + out_summary.table  +"'n " + out_summary._dsopts() 
        code += "; run;"
 
        if vars != 3:

--- a/saspy/sasdata.py
+++ b/saspy/sasdata.py
@@ -87,7 +87,7 @@ class SASdata:
             if self.sas.sascfg.mode == 'HTTP':
                 self.libref = 'WORK'
 
-        self.table    = table
+        self.table    = table.strip()
         self.dsopts   = dsopts if dsopts is not None else {}
         self.results  = results
         self.tabulate = sp2.Tabulate(sassession, self)
@@ -196,14 +196,14 @@ class SASdata:
         """
         topts = dict(self.dsopts)
         topts['obs'] = obs
-        code = "proc print data=" + self.libref + '.' + self.table + self.sas._dsopts(topts) + ";run;"
+        code = "proc print data=" + self.libref + ".'" + self.table + "'n " + self.sas._dsopts(topts) + ";run;"
 
         if self.sas.nosub:
             print(code)
             return
 
         if self.results.upper() == 'PANDAS':
-            code = "data _head ; set %s.%s %s; run;" % (self.libref, self.table, self.sas._dsopts(topts))
+            code = "data _head ; set %s.'%s'n %s; run;" % (self.libref, self.table, self.sas._dsopts(topts))
             return self._returnPD(code, '_head')
         else:
             ll = self._is_valid()
@@ -230,7 +230,7 @@ class SASdata:
         :return:
         """   
         code  = "proc sql;select count(*) format best32. into :lastobs from "
-        code += self.libref + '.' + self.table + self._dsopts()
+        code += self.libref + ".'" + self.table + "'n " + self._dsopts()
         code += ";%put lastobs=&lastobs lastobsend=;\nquit;"
 
         nosub = self.sas.nosub
@@ -254,8 +254,8 @@ class SASdata:
         topts['obs'] = lastobs
         topts['firstobs'] = firstobs
 
-        code  = "proc print data=" + self.libref + '.' 
-        code += self.table + self.sas._dsopts(topts) + ";run;"
+        code  = "proc print data=" + self.libref + ".'" 
+        code += self.table + "'n " + self.sas._dsopts(topts) + ";run;"
 
         self.sas.nosub = nosub
         if self.sas.nosub:
@@ -263,7 +263,7 @@ class SASdata:
             return
 
         if self.results.upper() == 'PANDAS':
-            code = "data _tail ; set %s.%s %s; run;" % (self.libref, self.table, self.sas._dsopts(topts))
+            code = "data _tail ; set %s.'%s'n %s; run;" % (self.libref, self.table, self.sas._dsopts(topts))
             return self._returnPD(code, '_tail')
         else:
             if self.HTML:
@@ -290,7 +290,7 @@ class SASdata:
         return the number of observations for your SASdata object
         """
         code  = "proc sql;select count(*) format best32. into :lastobs from "
-        code += self.libref + '.' + self.table + self._dsopts() 
+        code += self.libref + ".'" + self.table + "'n " + self._dsopts() 
         code += ";%put lastobs=&lastobs lastobsend=;\nquit;"
 
         if self.sas.nosub:
@@ -341,20 +341,20 @@ class SASdata:
             out_libref = out.libref
         else:
             try:
-                out_table = out.split('.')[1]
+                out_table = out.split('.')[1].strip()
                 out_libref = out.split('.')[0]
             except IndexError:
-                out_table = out
+                out_table = out.strip()
                 out_libref = 'work'
         while i <= k:
             # get the list of variables
             if k == 1:
-                code += "proc hpsample data=%s.%s %s out=%s.%s %s samppct=%s seed=%s Partition;\n" % (
+                code += "proc hpsample data=%s.'%s'n %s out=%s.'%s'n %s samppct=%s seed=%s Partition;\n" % (
                     self.libref, self.table, self._dsopts(), out_libref, out_table, self._dsopts(), fraction * 100,
                     seed)
             else:
                 seed += 1
-                code += "proc hpsample data=%s.%s %s out=%s.%s %s samppct=%s seed=%s partition PARTINDNAME=_cvfold%s;\n" % (
+                code += "proc hpsample data=%s.'%s'n %s out=%s.'%s'n %s samppct=%s seed=%s partition PARTINDNAME=_cvfold%s;\n" % (
                     self.libref, self.table, self._dsopts(), out_libref, out_table, self._dsopts(), fraction * 100,
                     seed, i)
 
@@ -363,7 +363,7 @@ class SASdata:
                 if i == 1:
                     num_string = """
                         data _null_; file LOG;
-                          d = open('{0}.{1}');
+                          d = open("{0}.'{1}'n");
                           nvars = attrn(d, 'NVARS'); 
                           put 'VARLIST=';
                           do i = 1 to nvars; 
@@ -414,12 +414,12 @@ class SASdata:
         if not singleOut:
             split_code += 'DATA '
             for j in range(1, k + 1):
-                split_code += "\t%s.%s%s_train(drop=_Partind_ _cvfold:)\n" % (out_libref, out_table, j)
-                split_code += "\t%s.%s%s_score(drop=_Partind_ _cvfold:)\n" % (out_libref, out_table, j)
-            split_code += ';\n \tset %s.%s;\n' % (out_libref, out_table)
+                split_code += "\t%s.'%s%s_train'n (drop=_Partind_ _cvfold:)\n" % (out_libref, out_table, j)
+                split_code += "\t%s.'%s%s_score'n (drop=_Partind_ _cvfold:)\n" % (out_libref, out_table, j)
+            split_code += ";\n \tset %s.'%s'n;\n" % (out_libref, out_table)
             for z in range(1, k + 1):
-                split_code += "\tif _cvfold%s = 1 or _partind_ = 1 then output %s.%s%s_train;\n" % (z, out_libref, out_table, z)
-                split_code += "\telse output %s.%s%s_score;\n" % (out_libref, out_table, z)
+                split_code += "\tif _cvfold%s = 1 or _partind_ = 1 then output %s.'%s%s_train'n;\n" % (z, out_libref, out_table, z)
+                split_code += "\telse output %s.'%s%s_score'n;\n" % (out_libref, out_table, z)
             split_code += 'run;'
         runcode = True
         if self.sas.nosub:
@@ -444,7 +444,7 @@ class SASdata:
 
                 for j in range(1, k + 1):
                     outTableList.append((self.sas.sasdata(out_table + str(j) + "_train", out_libref, dsopts=self._dsopts()),
-                                               self.sas.sasdata(out_table + str(j) + "_score", out_libref, dsopts=self._dsopts())))
+                                         self.sas.sasdata(out_table + str(j) + "_score", out_libref, dsopts=self._dsopts())))
                 return outTableList
             if out:
                 if not isinstance(out, str):
@@ -460,7 +460,7 @@ class SASdata:
 
         :return: output
         """
-        code = "proc contents data=" + self.libref + '.' + self.table + self._dsopts() + ";run;"
+        code = "proc contents data=" + self.libref + ".'" + self.table + "'n " + self._dsopts() + ";run;"
 
         if self.sas.nosub:
             print(code)
@@ -468,7 +468,7 @@ class SASdata:
 
         ll = self._is_valid()
         if self.results.upper() == 'PANDAS':
-            code  = "proc contents data=%s.%s %s ;" % (self.libref, self.table, self._dsopts())
+            code  = "proc contents data=%s.'%s'n %s ;" % (self.libref, self.table, self._dsopts())
             code += "ods output Attributes=work._attributes;"
             code += "ods output EngineHost=work._EngineHost;"
             code += "ods output Variables=work._Variables;"
@@ -496,14 +496,14 @@ class SASdata:
         """
         display metadata about the table, size, number of rows, columns and their data type
         """
-        code = "proc contents data=" + self.libref + '.' + self.table + ' ' + self._dsopts() + ";ods select Variables;run;"
+        code = "proc contents data=" + self.libref + ".'" + self.table + "'n " + self._dsopts() + ";ods select Variables;run;"
 
         if self.sas.nosub:
             print(code)
             return
 
         if self.results.upper() == 'PANDAS':
-            code = "proc contents data=%s.%s %s ;ods output Variables=work._variables ;run;" % (self.libref, self.table, self._dsopts())
+            code = "proc contents data=%s.'%s'n %s ;ods output Variables=work._variables ;run;" % (self.libref, self.table, self._dsopts())
             df = self._returnPD(code, '_variables')
             df['Type'] = df['Type'].str.rstrip()
             return df
@@ -537,7 +537,7 @@ class SASdata:
         info_code = """
         data work._statsInfo ;
             do rows=0 by 1 while( not last ) ;
-                set {0}.{1}{2} end=last;
+                set {0}.'{1}'n {2} end=last;
                 array chrs _character_ ;
                 array nums _numeric_ ;
                 array ccounts(999) _temporary_ ;
@@ -593,7 +593,7 @@ class SASdata:
         """
         dsopts = self._dsopts().partition(';\n\tformat')
 
-        code  = "proc means data=" + self.libref + '.' + self.table + dsopts[0] + " stackodsoutput n nmiss median mean std min p25 p50 p75 max;"
+        code  = "proc means data=" + self.libref + ".'" + self.table + "'n " + dsopts[0] + " stackodsoutput n nmiss median mean std min p25 p50 p75 max;"
         code += dsopts[1]+dsopts[2]+"run;"
 
         if self.sas.nosub:
@@ -603,7 +603,7 @@ class SASdata:
         ll = self._is_valid()
 
         if self.results.upper() == 'PANDAS':
-            code = "proc means data=%s.%s %s stackodsoutput n nmiss median mean std min p25 p50 p75 max; %s ods output Summary=work._summary; run;" % (
+            code = "proc means data=%s.'%s'n %s stackodsoutput n nmiss median mean std min p25 p50 p75 max; %s ods output Summary=work._summary; run;" % (
                 self.libref, self.table, dsopts[0], dsopts[1]+dsopts[2])
             return self._returnPD(code, '_summary')
         else:
@@ -638,21 +638,21 @@ class SASdata:
                 fn = out.partition('.')
                 if fn[1] == '.':
                     out_libref = fn[0]
-                    out_table = fn[2]
+                    out_table = fn[2].strip()
                 else:
                     out_libref = ''
-                    out_table = fn[0]
+                    out_table = fn[0].strip()
             else:
                 out_libref = out.libref
                 out_table = out.table
-            outstr = "out=%s.%s" % (out_libref, out_table)
+            outstr = "out=%s.'%s'n" % (out_libref, out_table)
 
         else:
             out_table = self.table
             out_libref = self.libref
 
         # get list of variables and types
-        varcode  = "data _null_; d = open('" + self.libref + "." + self.table + "');\n"
+        varcode  = 'data _null_; d = open("' + self.libref + ".'" + self.table + "'n " + '");\n'
         varcode += "nvars = attrn(d, 'NVARS');\n"
         varcode += "put 'VARNUMS=' nvars 'VARNUMS_END=';\n"
         varcode += "put 'VARLIST=';\n"
@@ -689,9 +689,9 @@ class SASdata:
         sqlsel = ' %s(%s),\n'
         sqlinto = ' into\n'
         if len(out_libref)>0 :
-            ds1 = "data " + out_libref + "." + out_table + "; set " + self.libref + "." + self.table + self._dsopts() + ";\n"
+            ds1 = "data " + out_libref + ".'" + out_table + "'n " + "; set " + self.libref + ".'" + self.table +"'n " + self._dsopts() + ";\n"
         else:
-            ds1 = "data " + out_table + "; set " + self.libref + "." + self.table + self._dsopts() + ";\n"
+            ds1 = "data '" + out_table + "'n " + "; set " + self.libref + "." + self.table + self._dsopts() + ";\n"
         dsmiss = 'if missing({0}) then {1} = {2};\n'
         if replace:
             dsmiss = prefix+'{1} = {0}; if missing({0}) then %s{1} = {2};\n' % prefix
@@ -729,14 +729,14 @@ class SASdata:
                     sql += sqlsel % (key, v)
                     sqlinto += ' :imp_' + v + ',\n'
                     if key.lower == 'mode':
-                        modesql += modeq % (v, v, self.libref + "." + self.table + self._dsopts() , v, v, v)
+                        modesql += modeq % (v, v, self.libref + ".'" + self.table + "'n " + self._dsopts() , v, v, v)
                     if varListType.get(v.upper()) == "N":
                         ds1 += dsmiss.format(v, v, '&imp_' + v + '.')
                     else:
                         ds1 += dsmiss.format(v, v, '"&imp_' + v + '."')
 
         if len(sql) > 20:
-            sql = sql.rstrip(', \n') + '\n' + sqlinto.rstrip(', \n') + '\n  from ' + self.libref + '.' + self.table + self._dsopts() + ';\nquit;\n'
+            sql = sql.rstrip(', \n') + '\n' + sqlinto.rstrip(', \n') + '\n  from ' + self.libref + ".'" + self.table + "'n " + self._dsopts() + ';\nquit;\n'
         else:
             sql = ''
         ds1 += 'run;\n'
@@ -774,21 +774,21 @@ class SASdata:
                 fn = out.partition('.')
                 if fn[1] == '.':
                     libref = fn[0]
-                    table = fn[2]
-                    outstr = "out=%s.%s" % (libref, table)
+                    table  = fn[2].strip()
+                    outstr = "out=%s.'%s'n" % (libref, table)
                 else:
                     libref = ''
-                    table = fn[0]
-                    outstr = "out=" + table
+                    table  = fn[0].strip()
+                    outstr = "out='" + table + "'n " 
             else:
                 libref = out.libref
-                table = out.table
-                outstr = "out=%s.%s" % (out.libref, out.table)
+                table  = out.table
+                outstr = "out=%s.'%s'n" % (out.libref, out.table)
 
         if 'options' in kwargs:
             options = kwargs['options']
 
-        code = "proc sort data=%s.%s%s %s %s ;\n" % (self.libref, self.table, self._dsopts(), outstr, options)
+        code = "proc sort data=%s.'%s'n %s %s %s ;\n" % (self.libref, self.table, self._dsopts(), outstr, options)
         code += "by %s;" % by
         code += "run\n;"
         runcode = True
@@ -840,11 +840,11 @@ class SASdata:
               print("out= needs to be a SASdata object")
               return None
            else:
-              outtab = out.libref + '.' + out.table + out._dsopts() 
+              outtab = out.libref + ".'" + out.table + "'n " + out._dsopts() 
         else:
-           outtab = self.libref + '.' + self.table + self._dsopts() 
+           outtab = self.libref + ".'" + self.table + "'n " + self._dsopts() 
 
-        code  = "data "+outtab+"; set " + self.libref + '.' + self.table + self._dsopts() + ";\n"
+        code  = "data "+outtab+"; set " + self.libref + ".'" + self.table + "'n " + self._dsopts() + ";\n"
         for key in vars.keys():
            code += key+" = "+vars[key]+";\n"
         code += "; run;"
@@ -882,7 +882,7 @@ class SASdata:
         code = "%macro proccall(d);\n"
 
         # build parameters
-        score_table = str(self.libref + '.' + self.table)
+        score_table = str(self.libref + ".'" + self.table + "'n " )
         binstats = str(objname + '.' + "ASSESSMENTSTATISTICS")
         out = str(objname + '.' + "ASSESSMENTBINSTATISTICS")
         level = 'interval'
@@ -895,7 +895,7 @@ class SASdata:
                     raise Exception(event)
             except Exception:
                 print("No event was specified for a nominal target. Here are possible options:\n")
-                event_code = "proc hpdmdb data=%s.%s %s classout=work._DMDBCLASSTARGET(keep=name nraw craw level frequency nmisspercent);" % (
+                event_code = "proc hpdmdb data=%s.'%s'n %s classout=work._DMDBCLASSTARGET(keep=name nraw craw level frequency nmisspercent);" % (
                     self.libref, self.table, self._dsopts())
                 event_code += "\nclass %s ; \nrun;" % target
                 event_code += "data _null_; set work._DMDBCLASSTARGET; where ^(NRAW eq . and CRAW eq '') and lowcase(name)=lowcase('%s');" % target
@@ -962,7 +962,7 @@ class SASdata:
             """
             code += graphics.format(out)
         code += "run; quit; %mend;\n"
-        code += "%%mangobj(%s,%s,%s);" % (objname, objtype, self.table)
+        code += "%%mangobj(%s,%s,'%s'n);" % (objname, objtype, self.table)
 
         if self.sas.nosub:
             print(code)
@@ -1005,8 +1005,8 @@ class SASdata:
             outTable = self.table
             outLibref = self.libref
         codestr = code
-        code = "data %s.%s%s;" % (outLibref, outTable, self._dsopts())
-        code += "set %s.%s%s;" % (self.libref, self.table, self._dsopts())
+        code = "data %s.'%s'n %s;" % (outLibref, outTable, self._dsopts())
+        code += "set %s.'%s'n %s;" % (self.libref, self.table, self._dsopts())
         if len(file)>0:
             code += '%%include "%s";' % file
         else:
@@ -1083,7 +1083,7 @@ class SASdata:
             code += " pretty "
         if not sastag:
             code += " nosastags "
-        code +=";\n  export %s.%s %s;\n run;" % (self.libref, self.table, self._dsopts())
+        code +=";\n  export %s.'%s'n %s;\n run;" % (self.libref, self.table, self._dsopts())
 
         if self.sas.nosub:
             print(code)
@@ -1122,7 +1122,7 @@ class SASdata:
         :param label:
         :return:
         """
-        code = "proc sgplot data=%s.%s %s;" % (self.libref, self.table, self._dsopts())
+        code = "proc sgplot data=%s.'%s'n %s;" % (self.libref, self.table, self._dsopts())
         if len(options):
             code += "\n\theatmap x='%s'n y='%s'n / %s;" % (x, y, options)
         else:
@@ -1160,7 +1160,7 @@ class SASdata:
         :param label: LegendLABEL= value for sgplot
         :return:
         """
-        code = "proc sgplot data=" + self.libref + '.' + self.table + self._dsopts()
+        code = "proc sgplot data=" + self.libref + ".'" + self.table + "'n " + self._dsopts()
         code += ";\n\thistogram '" + var + "'n / scale=count"
         if len(label) > 0:
             code += " LegendLABEL='" + label + "'"
@@ -1194,7 +1194,7 @@ class SASdata:
         :param title: an optional Title for the chart
         :return: Data Table
         """
-        code = "proc freq data=%s.%s %s order=%s noprint;" % (self.libref, self.table, self._dsopts(), order)
+        code = "proc freq data=%s.'%s'n %s order=%s noprint;" % (self.libref, self.table, self._dsopts(), order)
         code += "\n\ttables '%s'n / out=tmpFreqOut;" % var
         code += "\nrun;"
         if len(title) > 0:
@@ -1208,7 +1208,7 @@ class SASdata:
 
         ll = self._is_valid()
         if self.results.upper() == 'PANDAS':
-            code = "proc freq data=%s.%s%s order=%s noprint;" % (self.libref, self.table, self._dsopts(), order)
+            code = "proc freq data=%s.'%s'n %s order=%s noprint;" % (self.libref, self.table, self._dsopts(), order)
             code += "\n\ttables '%s'n / out=tmpFreqOut;" % var
             code += "\nrun;"
             code += "\ndata tmpFreqOut; set tmpFreqOut(obs=%s); run;" % n
@@ -1239,7 +1239,7 @@ class SASdata:
         :param label: LegendLABEL= value for sgplot
         :return: graphic plot
         """
-        code = "proc sgplot data=" + self.libref + '.' + self.table + self._dsopts()
+        code = "proc sgplot data=" + self.libref + ".'" + self.table + "'n " + self._dsopts()
         code += ";\n\tvbar '" + var + "'n" 
         if len(label) > 0:
             code += " / LegendLABEL='" + label + "'"
@@ -1273,7 +1273,7 @@ class SASdata:
         :return: graph object
         """
 
-        code = "proc sgplot data=" + self.libref + '.' + self.table + self._dsopts() + ";\n"
+        code = "proc sgplot data=" + self.libref + ".'" + self.table + "'n " + self._dsopts() + ";\n"
         if len(title) > 0:
             code += '\ttitle "' + title + '";\n'
 
@@ -1313,7 +1313,7 @@ class SASdata:
         :return: graph object
         """
 
-        code = "proc sgplot data=" + self.libref + '.' + self.table + self._dsopts() + ";\n"
+        code = "proc sgplot data=" + self.libref + ".'" + self.table + "'n " + self._dsopts() + ";\n"
         if len(title) > 0:
             code += '\ttitle "' + title + '";\n'
 

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -253,7 +253,7 @@ class SASSessionCOM(object):
         self.adodb.Open('Provider={}; Data Source=iom-id://{}'.format(
             self.sascfg.provider, self.workspace.UniqueIdentifier))
 
-        ll = self.submit("options svgtitle='svgtitle'; options validvarname=any pagesize=max nosyntaxcheck; ods graphics on;", "text")
+        ll = self.submit("options svgtitle='svgtitle'; options validvarname=any validmemname=extend pagesize=max nosyntaxcheck; ods graphics on;", "text")
         if self.sascfg.verbose:
             print("SAS Connection established. Workspace UniqueIdentifier is "+str(self.workspace.UniqueIdentifier)+"\n")
 

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -361,9 +361,9 @@ class SASSessionCOM(object):
         :return [str]:
         """
         if not libref:
-            path = table
+            path = "'{}'n".format(table.strip())
         else:
-            path = '{}.{}'.format(libref, table)
+            path = "{}.'{}'n".format(libref, table.strip())
 
         return path
 
@@ -374,7 +374,12 @@ class SASSessionCOM(object):
         :option libref [str]: Library name.
         :return [dict]:
         """
-        tablepath = self._tablepath(table, libref=libref)
+        #tablepath = self._tablepath(table, libref=libref)
+        if not libref:
+            tablepath = table
+        else:
+            tablepath = "{}.{}".format(libref, table)
+
         criteria = [None, None, tablepath]
 
         schema = self.adodb.OpenSchema(self.SCHEMA_COLUMNS, criteria)
@@ -514,11 +519,11 @@ class SASSessionCOM(object):
         code  = "data _null_; e = %sysfunc(exist("
         if len(libref):
            code += libref+"."
-        code += table+"));\n"
+        code += "'"+table.strip()+"'n));\n"
         code += "v = %sysfunc(exist("
         if len(libref):
            code += libref+"."
-        code += table+", 'VIEW'));\n if e or v then e = 1;\n"
+        code += "'"+table.strip()+"'n, 'VIEW'));\n if e or v then e = 1;\n"
         code += "te='TABLE_EXISTS='; put te e;run;\n"
       
         ll = self.submit(code, "text")

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -472,7 +472,7 @@ class SASsessionHTTP():
             print(key+"="+str(jobid.get(key)))
          return None
 
-      ll = self.submit("options svgtitle='svgtitle'; options validvarname=any pagesize=max nosyntaxcheck; ods graphics on;", "text")
+      ll = self.submit("options svgtitle='svgtitle'; options validvarname=any validmemname=extend pagesize=max nosyntaxcheck; ods graphics on;", "text")
       if self.sascfg.verbose:
          print("SAS server started using Context "+self.sascfg.ctxname+" with SESSION_ID="+self.pid)       
 
@@ -802,10 +802,10 @@ class SASsessionHTTP():
 
       code  = "data _null_; e = %sysfunc(exist("
       code += libref+"."
-      code += table+"));\n"
+      code += "'"+table.strip()+"'n));\n"
       code += "v = %sysfunc(exist("
       code += libref+"."
-      code += table+", 'VIEW'));\n if e or v then e = 1;\n"
+      code += "'"+table.strip()+"'n, 'VIEW'));\n if e or v then e = 1;\n"
       code += "te='TABLE_EXISTS='; put te e;run;\n"
 
       ll = self.submit(code, "text")
@@ -850,7 +850,7 @@ class SASsessionHTTP():
       code += "proc import datafile=x out="
       if len(libref):
          code += libref+"."
-      code += table+" dbms=csv replace; "+self._sb._impopts(opts)+" run;"
+      code += "'"+table.strip()+"'n dbms=csv replace; "+self._sb._impopts(opts)+" run;"
    
       if nosub:
          print(code)
@@ -867,7 +867,12 @@ class SASsessionHTTP():
       '''
       code  = "filename x \""+file+"\";\n"
       code += "options nosource;\n"
-      code += "proc export data="+libref+"."+table+self._sb._dsopts(dsopts)+" outfile=x dbms=csv replace; "
+      code += "proc export data="
+
+      if len(libref):
+         code += libref+"."
+
+      code += "'"+table.strip()+"'n "+self._sb._dsopts(dsopts)+" outfile=x dbms=csv replace; "
       code += self._sb._expopts(opts)+" run\n;"
       code += "options source;\n"
 
@@ -1092,7 +1097,7 @@ class SASsessionHTTP():
       code = "data "
       if len(libref):
          code += libref+"."
-      code += table+";\n"
+      code += "'"+table.strip()+"'n;\n"
       if len(length):
          code += "length "+length+";\n"
       if len(format):
@@ -1146,9 +1151,9 @@ class SASsessionHTTP():
          return self.sasdata2dataframeCSV(table, libref, dsopts, **kwargs)
 
       if libref:
-         tabname = libref+"."+table
+         tabname = libref+".'"+table.strip()+"'n "
       else:
-         tabname = table
+         tabname = "'"+table.strip()+"'n "
 
       code  = "proc sql; create view work.sasdata2dataframe as select * from "+tabname+self._sb._dsopts(dsopts)+";quit;\n"
 
@@ -1300,9 +1305,9 @@ class SASsessionHTTP():
       '''
 
       if libref:
-         tabname = libref+"."+table
+         tabname = libref+".'"+table.strip()+"'n "
       else:
-         tabname = table
+         tabname = "'"+table.strip()+"'n "
 
       tmpdir  = None
 

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -472,7 +472,7 @@ Will use HTML5 for this SASsession.""")
       enc = self.sascfg.encoding #validating encoding is done next, so handle it not being set for this one call
       if enc == '':
          self.sascfg.encoding = 'utf-8'
-      ll = self.submit("options svgtitle='svgtitle'; options validvarname=any pagesize=max nosyntaxcheck; ods graphics on;", "text")
+      ll = self.submit("options svgtitle='svgtitle'; options validvarname=any validmemname=extend pagesize=max nosyntaxcheck; ods graphics on;", "text")
       self.sascfg.encoding = enc
 
       if self.pid is None:
@@ -1062,11 +1062,11 @@ Will use HTML5 for this SASsession.""")
       code  = "data _null_; e = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+"));\n"
+      code += "'"+table.strip()+"'n));\n"
       code += "v = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+", 'VIEW'));\n if e or v then e = 1;\n"
+      code += "'"+table.strip()+"'n, 'VIEW'));\n if e or v then e = 1;\n"
       code += "te='TABLE_EXISTS='; put te e;run;\n"
 
       ll = self.submit(code, "text")
@@ -1096,7 +1096,7 @@ Will use HTML5 for this SASsession.""")
       code += "proc import datafile=x out="
       if len(libref):
          code += libref+"."
-      code += table+" dbms=csv replace; "+self._sb._impopts(opts)+" run;"
+      code += "'"+table.strip()+"'n dbms=csv replace; "+self._sb._impopts(opts)+" run;"
 
       if nosub:
          print(code)
@@ -1117,7 +1117,12 @@ Will use HTML5 for this SASsession.""")
 
       code  = "filename x \""+file+"\";\n"
       code += "options nosource;\n"
-      code += "proc export data="+libref+"."+table+self._sb._dsopts(dsopts)+" outfile=x dbms=csv replace; "
+      code += "proc export data="
+
+      if len(libref):
+         code += libref+"."
+
+      code += "'"+table.strip()+"'n "+self._sb._dsopts(dsopts)+" outfile=x dbms=csv replace; "
       code += self._sb._expopts(opts)+" run\n;"
       code += "options source;\n"
 
@@ -1442,7 +1447,7 @@ Will use HTML5 for this SASsession.""")
       code = "data "
       if len(libref):
          code += libref+"."
-      code += table+";\n"
+      code += "'"+table.strip()+"'n;\n"
       if len(length):
          code += "length "+length+";\n"
       if len(format):
@@ -1505,9 +1510,9 @@ Will use HTML5 for this SASsession.""")
       logcodeb =  logcodeo.encode()
 
       if libref:
-         tabname = libref+"."+table
+         tabname = libref+".'"+table.strip()+"'n "
       else:
-         tabname = table
+         tabname = "'"+table.strip()+"'n "
 
       code  = "proc sql; create view sasdata2dataframe as select * from "+tabname+self._sb._dsopts(dsopts)+";quit;\n"
       code += "data _null_; file LOG; d = open('sasdata2dataframe');\n"
@@ -1710,9 +1715,9 @@ Will use HTML5 for this SASsession.""")
       logcodeo = "\nE3969440A681A24088859985" + logn
 
       if libref:
-         tabname = libref+"."+table
+         tabname = libref+".'"+table.strip()+"'n "
       else:
-         tabname = table
+         tabname = "'"+table.strip()+"'n "
 
       tmpdir  = None
 

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1059,14 +1059,14 @@ Will use HTML5 for this SASsession.""")
 
       Returns True it the Data Set exists and False if it does not
       """
-      code  = "data _null_; e = exist('"
+      code  = "data _null_; e = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+"');\n"
-      code += "v = exist('"
+      code += table+"));\n"
+      code += "v = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+"', 'VIEW');\n if e or v then e = 1;\n"
+      code += table+", 'VIEW'));\n if e or v then e = 1;\n"
       code += "te='TABLE_EXISTS='; put te e;run;\n"
 
       ll = self.submit(code, "text")

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -355,7 +355,7 @@ Will use HTML5 for this SASsession.""")
          enc = self.sascfg.encoding #validating encoding is done next, so handle it not being set for this one call
          if enc == '':
             self.sascfg.encoding = 'utf-8'
-         ll = self.submit("options svgtitle='svgtitle'; options validvarname=any; ods graphics on;", "text")
+         ll = self.submit("options svgtitle='svgtitle'; options validvarname=any validmemname=extend; ods graphics on;", "text")
          self.sascfg.encoding = enc
          if self.pid is None:
             print("SAS Connection failed. No connection established. Double check your settings in sascfg_personal.py file.\n")
@@ -907,11 +907,11 @@ Will use HTML5 for this SASsession.""")
       code  = "data _null_; e = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+"));\n"
+      code += "'"+table.strip()+"'n));\n"
       code += "v = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+", 'VIEW'));\n if e or v then e = 1;\n"
+      code += "'"+table.strip()+"'n, 'VIEW'));\n if e or v then e = 1;\n"
       code += "put 'TABLE_EXISTS=' e 'TAB_EXTEND=';run;"
 
       ll = self.submit(code, "text")
@@ -939,7 +939,7 @@ Will use HTML5 for this SASsession.""")
       if len(libref):
          code += libref+"."
 
-      code += table+" dbms=csv replace; "+self._sb._impopts(opts)+" run;"
+      code += "'"+table.strip()+"'n dbms=csv replace; "+self._sb._impopts(opts)+" run;"
 
       if nosub:
          print(code)
@@ -960,8 +960,13 @@ Will use HTML5 for this SASsession.""")
 
       code  = "filename x \""+file+"\";\n"
       code += "options nosource;\n"
-      code += "proc export data="+libref+"."+table+self._sb._dsopts(dsopts)+" outfile=x"
-      code += " dbms=csv replace; "+self._sb._expopts(opts)+" run;"
+      code += "proc export data="
+
+      if len(libref):
+         code += libref+"."
+
+      code += "'"+table.strip()+"'n "+self._sb._dsopts(dsopts)+" outfile=x dbms=csv replace; "
+      code += self._sb._expopts(opts)+" run;\n"
       code += "options source;\n"
 
       if nosub:
@@ -1411,7 +1416,7 @@ Will use HTML5 for this SASsession.""")
       code = "data "
       if len(libref):
          code += libref+"."
-      code += table+";\n"
+      code += "'"+table.strip()+"'n;\n"
       if len(length):
          code += "length"+length+";\n"
       if len(format):
@@ -1475,9 +1480,9 @@ Will use HTML5 for this SASsession.""")
       datar = ""
 
       if libref:
-         tabname = libref+"."+table
+         tabname = libref+".'"+table.strip()+"'n "
       else:
-         tabname = table
+         tabname = "'"+table.strip()+"'n "
 
       code  = "proc sql; create view sasdata2dataframe as select * from "+tabname+self._sb._dsopts(dsopts)+";quit;\n"
       code += "data _null_; file STDERR;d = open('sasdata2dataframe');\n"
@@ -1670,9 +1675,9 @@ Will use HTML5 for this SASsession.""")
          port = self.sascfg.tunnel
 
       if libref:
-         tabname = libref+"."+table
+         tabname = libref+".'"+table.strip()+"'n "
       else:
-         tabname = table
+         tabname = "'"+table.strip()+"'n "
 
       tmpdir  = None
 

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -355,7 +355,7 @@ Will use HTML5 for this SASsession.""")
          enc = self.sascfg.encoding #validating encoding is done next, so handle it not being set for this one call
          if enc == '':
             self.sascfg.encoding = 'utf-8'
-         self.submit("options svgtitle='svgtitle'; options validvarname=any; ods graphics on;", "text")
+         ll = self.submit("options svgtitle='svgtitle'; options validvarname=any; ods graphics on;", "text")
          self.sascfg.encoding = enc
          if self.pid is None:
             print("SAS Connection failed. No connection established. Double check your settings in sascfg_personal.py file.\n")
@@ -904,14 +904,14 @@ Will use HTML5 for this SASsession.""")
 
       Returns True it the Data Set exists and False if it does not
       """
-      code  = "data _null_; e = exist('"
+      code  = "data _null_; e = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+"');\n"
-      code += "v = exist('"
+      code += table+"));\n"
+      code += "v = %sysfunc(exist("
       if len(libref):
          code += libref+"."
-      code += table+"', 'VIEW');\n if e or v then e = 1;\n"
+      code += table+", 'VIEW'));\n if e or v then e = 1;\n"
       code += "put 'TABLE_EXISTS=' e 'TAB_EXTEND=';run;"
 
       ll = self.submit(code, "text")


### PR DESCRIPTION
This has the changes for supporting N-literal syntax for data set names. This is all done in saspy code so the user doesn't have to use N-literal syntax to get non-SAS conforming table names to work right.