### PR TITLE
M5bug

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -515,12 +515,12 @@ class SASsession():
             self.submit(self.sascfg.autoexec)
 
         if self.sascfg.m5dsbug is None:
-           if self.sasver[:9] in ['9.04.01M5', 'V.03.04M0', 'V.03.03M0']:
+           if self.sasver[:9] in ['9.04.01M5']: #, 'V.03.04M0', 'V.03.03M0']: couldn't reproduce on SPRE
               self.m5dsbug = True
-              print("There is a known bug in the Data Step in 940M5. This session is conected to that version or") 
-              print("an equivalent SPRE version. Setting 'm5dsbug' to True to use alternate code to work around this bug.") 
-              print("You can eliminate this message by setting {'m5dsbug' : True} of to False it it has been hotfixed")
-              print("in your configuration definition for this connection. Or on:  SASsession(m5dsbug = [True | False])")
+              print("There is a known bug in the Data Step in 940M5. This session is conected to that version.") 
+              print("Setting 'm5dsbug' to True to use alternate code to work around this bug.") 
+              print("You can eliminate this message by setting {'m5dsbug' : True} (or to False it it has been hotfixed)")
+              print("in your configuration definition for this connection, or on SASsession(m5dsbug = [True | False])")
            else:
               self.m5dsbug = False
         else:

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -172,6 +172,7 @@ class SASconfig(object):
         self.display  = cfg.get('display',  '')
         self.results  = cfg.get('results')
         self.autoexec = cfg.get('autoexec')
+        self.m5dsbug  = cfg.get('m5dsbug')
 
         indisplay = kwargs.get('display', '')
         if len(indisplay) > 0:
@@ -202,6 +203,10 @@ class SASconfig(object):
                 print("Parameter 'autoexec' passed to SAS_session was ignored due to configuration restriction.")
             else:
                 self.autoexec = inautoexec
+
+        inm5dsbug = kwargs.get('m5dsbug', None)
+        if inm5dsbug:
+           self.m5dsbug = inm5dsbug
 
         if java is not None:
             self.mode = 'IOM'
@@ -509,6 +514,16 @@ class SASsession():
         if self.sascfg.autoexec:
             self.submit(self.sascfg.autoexec)
 
+        if self.sascfg.m5dsbug is None:
+           if self.sasver[:9] in ['9.04.01M5', 'V.03.04M0', 'V.03.03M0']:
+              self.m5dsbug = True
+              print("There is a known bug in the Data Step in 940M5. This session is conected to that version or") 
+              print("an equivalent SPRE version. Setting 'm5dsbug' to True to use alternate code to work around this bug.") 
+              print("You can eliminate this message by setting {'m5dsbug' : True} of to False it it has been hotfixed")
+              print("in your configuration definition for this connection. Or on:  SASsession(m5dsbug = [True | False])")
+           else:
+              self.m5dsbug = False
+                 
         # this is to support parsing the log to fring log records w/ 'ERROR' when diagnostic logging is enabled.
         # in thi scase the log can have prefix and/or suffix info so the 'regular' log data is in the middle, not left justified
         if self.sascfg.mode in ['STDIO', 'SSH', '']:

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -491,19 +491,19 @@ class SASsession():
                  print("Using encoding "+pyenc[0]+" instead to avoid transcoding problems.")
                  self._io.sascfg.encoding = pyenc[0]
                  print("You can override this change, if you think you must, by changing the encoding attribute of the SASsession object, as follows.")
-                 print("""If you had 'sas = saspy.SASsession(), then submit: "sas._io.sascfg.encoding='override_encoding'" to change it""")
+                 print("""If you had 'sas = saspy.SASsession(), then submit: "sas._io.sascfg.encoding='override_encoding'" to change it.\n""")
            else:
               self._io.sascfg.encoding = pyenc[0]
               if self._io.sascfg.verbose:
                  print("No encoding value provided. Will try to determine the correct encoding.")
-                 print("Setting encoding to "+pyenc[0]+" based upon the SAS session encoding value of "+self.sascei+".")
+                 print("Setting encoding to "+pyenc[0]+" based upon the SAS session encoding value of "+self.sascei+".\n")
         else:
            print("The SAS session encoding for this session ("+self.sasce+") doesn't have a known Python equivalent encoding.")
            if self._io.sascfg.encoding == '':
               self._io.sascfg.encoding  = 'utf_8'
-              print("Proceeding using the default encoding of 'utf_8', though you may encounter transcoding problems.")
+              print("Proceeding using the default encoding of 'utf_8', though you may encounter transcoding problems.\n")
            else:
-              print("Proceeding using the specified encoding of "+self._io.sascfg.encoding+", though you may encounter transcoding problems.")
+              print("Proceeding using the specified encoding of "+self._io.sascfg.encoding+", though you may encounter transcoding problems.\n")
 
         if self.hostsep == 'WIN':
             self.hostsep = '\\'
@@ -515,12 +515,13 @@ class SASsession():
             self.submit(self.sascfg.autoexec)
 
         if self.sascfg.m5dsbug is None:
-           if self.sasver[:9] in ['9.04.01M5']: #, 'V.03.04M0', 'V.03.03M0']: couldn't reproduce on SPRE
+           if self.sasver[:9] in ['9.04.01M5'] and self.sascei in ['utf-8', 'euc-cn', 'euc-jp', 'euc-kr', 'shift-jis', 'big5']:
+           #if self.sasver[:9] in ['9.04.01M5']: #, 'V.03.04M0', 'V.03.03M0']: couldn't reproduce on SPRE
               self.m5dsbug = True
-              print("There is a known bug in the Data Step in 940M5. This session is conected to that version.") 
-              print("Setting 'm5dsbug' to True to use alternate code to work around this bug.") 
-              print("You can eliminate this message by setting {'m5dsbug' : True} (or to False it it has been hotfixed)")
-              print("in your configuration definition for this connection, or on SASsession(m5dsbug = [True | False])")
+              print("There is a known bug in the Data Step in 9.40M5 with multibyte encodings. This session is connected to that version") 
+              print("running with a multibyte encoding. Setting 'm5dsbug' to True to use alternate code to work around this bug.") 
+              print("You can eliminate this message by setting {'m5dsbug' : True} (or to False if the deployment has been hotfixed)")
+              print("in your configuration definition for this connection, or on SASsession(m5dsbug = [True | False]).\n")
            else:
               self.m5dsbug = False
         else:

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -523,6 +523,8 @@ class SASsession():
               print("in your configuration definition for this connection. Or on:  SASsession(m5dsbug = [True | False])")
            else:
               self.m5dsbug = False
+        else:
+           self.m5dsbug = self.sascfg.m5dsbug
                  
         # this is to support parsing the log to fring log records w/ 'ERROR' when diagnostic logging is enabled.
         # in thi scase the log can have prefix and/or suffix info so the 'regular' log data is in the middle, not left justified

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1558,7 +1558,8 @@ class SASsessionHTTP():
       miss = ['.', ' ']
 
       df = pd.read_csv(tmpcsv, index_col=False, engine='c', header=None, names=varlist, 
-                       sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss, **kwargs)
+                       sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss,
+                       encoding=self.sascfg.encoding, **kwargs)
 
       if tmpdir:
          tmpdir.cleanup()

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -235,6 +235,8 @@ class SASsessionIOM():
       self._log     = ""
       self._tomods1 = b"_tomods1"
 
+      self._sb.m5dsbug01 = True
+
       self._startsas()
 
    def __del__(self):
@@ -1597,23 +1599,31 @@ Will use HTML5 for this SASsession.""")
             if i % 10 == 0:
                code +='\n'
 
-      code += "file "+self._tomods1.decode()+" lrecl=1 recfm=f encoding=binary;\n"
+      if self._sb.m5dsbug01:
+         rsep = colsep+rowsep+'\n'
+         code += "file "+self._tomods1.decode()+" dlm="+cdelim+" termstr=NL;\nput "
+         for i in range(nvars):
+            code += " '"+varlist[i]+"'n "
+            if i % 10 == 0:
+               code +='\n'
+         code += rdelim+";\nrun;"
+      else:
+         rsep = rowsep
+         code += "file "+self._tomods1.decode()+" lrecl=1 recfm=f encoding=binary;\n"
+         last  = len(varlist)-1
+         for i in range(nvars):
+            code += "put '"+varlist[i]+"'n "
+            if i != last:
+               code += cdelim+'; '
+            else:
+               code += rdelim+'; '
+            if i % 10 == 0:
+               code +='\n'
+         code += "run;"
 
-      last  = len(varlist)-1
-      for i in range(nvars):
-         code += "put '"+varlist[i]+"'n "
-         if i != last:
-            code += cdelim+'; '
-         else:
-            code += rdelim+'; '
-         if i % 10 == 0:
-            code +='\n'
-      code += "run;"
       ll = self._asubmit(code, 'text')
-
       self.stdin[0].send(b'\n'+logcodei.encode()+b'\n'+b'tom says EOL='+logcodeb+b'\n')
-
-
+     
       BOM   = "\ufeff".encode()
       done  = False
       first = True
@@ -1659,12 +1669,12 @@ Will use HTML5 for this SASsession.""")
                    first = False
 
                 datar += data
-                data   = datar.rpartition(rowsep.encode())
+                data   = datar.rpartition(rsep.encode())
                 datap  = data[0]+data[1]
                 datar  = data[2]
 
                 datap = datap.decode(self.sascfg.encoding, errors='replace')
-                for i in datap.split(sep=rowsep):
+                for i in datap.split(sep=rsep):
                    if i != '':
                       r.append(tuple(i.split(sep=colsep)))
 
@@ -2042,12 +2052,17 @@ Will use HTML5 for this SASsession.""")
       varcat = l2[2].split("\n", nvars)
       del varcat[nvars]
 
-      if self.sascfg.iomhost.lower() in ('', 'localhost', '127.0.0.1'):
+      if self.sascfg.iomhost.lower() in ('', 'localhost', '127.0.0.1') and not self._sb.m5dsbug01:
          local   = True
+         enc     = self.sascfg.encoding
          outname = "_tomodsx"
-         code    = "filename _tomodsx '"+tmpcsv+"' lrecl=1 recfm=f encoding=binary;\n"
+         if self._sb.m5dsbug01:
+            code    = "filename _tomodsx '"+tmpcsv+"' lrecl="+str(self.sascfg.lrecl)+" recfm=v termstr=NL;\n"
+         else:
+            code    = "filename _tomodsx '"+tmpcsv+"' lrecl=1 recfm=f encoding=binary;\n"
       else:
          local   = False
+         enc     = 'utf_8'
          outname = self._tomods1.decode()
          code    = ""
 
@@ -2072,21 +2087,29 @@ Will use HTML5 for this SASsession.""")
             if i % 10 == 0:
                code +='\n'
 
-      code += "file "+outname+" lrecl=1 recfm=f encoding=binary;\n"
-
-      last  = len(varlist)-1
-      for i in range(nvars):
-         code += "put '"+varlist[i]+"'n "
-         if i != last:
-            code += cdelim+'; '
-         else:
-            code += rdelim+'; '
-         if i % 10 == 0:
-            code +='\n'
-      code += "run;"
+      if self._sb.m5dsbug01:
+         rsep = colsep+rowsep+'\n'
+         code += "file "+outname+" dlm="+cdelim+" termstr=NL;\nput "
+         for i in range(nvars):
+            code += " '"+varlist[i]+"'n "
+            if i % 10 == 0:
+               code +='\n'
+         code += rdelim+";\nrun;"
+      else:
+         rsep = rowsep
+         code += "file "+outname+" lrecl=1 recfm=f encoding=binary;\n"
+         last  = len(varlist)-1
+         for i in range(nvars):
+            code += "put '"+varlist[i]+"'n "
+            if i != last:
+               code += cdelim+'; '
+            else:
+               code += rdelim+'; '
+            if i % 10 == 0:
+               code +='\n'
+         code += "run;"
 
       ll = self._asubmit(code, "text")
-
       self.stdin[0].send(b'\n'+logcodei.encode()+b'\n'+b'tom says EOL='+logcodeo.encode())
 
       done  = False
@@ -2121,7 +2144,7 @@ Will use HTML5 for this SASsession.""")
 
                     if len(data) > 0:
                        datar += data
-                       data   = datar.rpartition(rowsep.encode())
+                       data   = datar.rpartition(rsep.encode())
                        datap  = data[0]+data[1]
                        datar  = data[2]
 
@@ -2130,7 +2153,10 @@ Will use HTML5 for this SASsession.""")
                           datar = datap.rpartition(logcodeo.encode())
                           datap = datar[0]
 
-                       csv.write(datap.decode(self.sascfg.encoding, errors='replace'))
+                       if not self._sb.m5dsbug01:
+                          csv.write(datap.decode(self.sascfg.encoding, errors='replace'))
+                       else:
+                          csv.write(datap.decode(self.sascfg.encoding, errors='replace').replace(rsep,rowsep))
                        if bail and done:
                           break
                     else:
@@ -2194,7 +2220,8 @@ Will use HTML5 for this SASsession.""")
       miss = ['.', ' ']
 
       df = pd.read_csv(tmpcsv, index_col=False, engine='c', header=None, names=varlist, 
-                       sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss, **kwargs)
+                       sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss,
+                       encoding=enc, **kwargs)
 
       if tmpdir:
          tmpdir.cleanup()

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -235,8 +235,6 @@ class SASsessionIOM():
       self._log     = ""
       self._tomods1 = b"_tomods1"
 
-      self._sb.m5dsbug01 = True
-
       self._startsas()
 
    def __del__(self):
@@ -1599,7 +1597,7 @@ Will use HTML5 for this SASsession.""")
             if i % 10 == 0:
                code +='\n'
 
-      if self._sb.m5dsbug01:
+      if self._sb.m5dsbug:
          rsep = colsep+rowsep+'\n'
          code += "file "+self._tomods1.decode()+" dlm="+cdelim+" termstr=NL;\nput "
          for i in range(nvars):
@@ -2052,11 +2050,11 @@ Will use HTML5 for this SASsession.""")
       varcat = l2[2].split("\n", nvars)
       del varcat[nvars]
 
-      if self.sascfg.iomhost.lower() in ('', 'localhost', '127.0.0.1') and not self._sb.m5dsbug01:
+      if self.sascfg.iomhost.lower() in ('', 'localhost', '127.0.0.1') and not self._sb.m5dsbug:
          local   = True
          enc     = self.sascfg.encoding
          outname = "_tomodsx"
-         if self._sb.m5dsbug01:
+         if self._sb.m5dsbug:
             code    = "filename _tomodsx '"+tmpcsv+"' lrecl="+str(self.sascfg.lrecl)+" recfm=v termstr=NL;\n"
          else:
             code    = "filename _tomodsx '"+tmpcsv+"' lrecl=1 recfm=f encoding=binary;\n"
@@ -2087,7 +2085,7 @@ Will use HTML5 for this SASsession.""")
             if i % 10 == 0:
                code +='\n'
 
-      if self._sb.m5dsbug01:
+      if self._sb.m5dsbug:
          rsep = colsep+rowsep+'\n'
          code += "file "+outname+" dlm="+cdelim+" termstr=NL;\nput "
          for i in range(nvars):
@@ -2153,7 +2151,7 @@ Will use HTML5 for this SASsession.""")
                           datar = datap.rpartition(logcodeo.encode())
                           datap = datar[0]
 
-                       if not self._sb.m5dsbug01:
+                       if not self._sb.m5dsbug:
                           csv.write(datap.decode(self.sascfg.encoding, errors='replace'))
                        else:
                           csv.write(datap.decode(self.sascfg.encoding, errors='replace').replace(rsep,rowsep))

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1,4 +1,4 @@
-#
+#             
 # Copyright SAS Institute
 #
 #  Licensed under the Apache License, Version 2.0 (the License);
@@ -200,8 +200,6 @@ class SASsessionSTDIO():
       self.sascfg   = SASconfigSTDIO(self, **kwargs)
       self._log_cnt = 0
       self._log     = ""
-
-      self._sb.m5dsbug01 = True
 
       self._startsas()
 
@@ -1559,7 +1557,7 @@ Will use HTML5 for this SASsession.""")
       rdelim = "'"+'%02x' % ord(rowsep.encode(self.sascfg.encoding))+"'x"
       cdelim = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x"
 
-      if self._sb.m5dsbug01:
+      if self._sb.m5dsbug:
          code = "filename sock socket '"+host+":"+str(port)+"' lrecl="+str(self.sascfg.lrecl)+" recfm=v termstr=LF;\n"
       else:
          code = "filename sock socket '"+host+":"+str(port)+"' lrecl=1 recfm=f encoding=binary;\n"
@@ -1582,7 +1580,7 @@ Will use HTML5 for this SASsession.""")
             if i % 10 == 0:
                code +='\n'
 
-      if self._sb.m5dsbug01:
+      if self._sb.m5dsbug:
          rsep = colsep+rowsep+'\n'
          code += "file sock dlm="+cdelim+";\nput "
          for i in range(nvars):
@@ -1956,7 +1954,7 @@ Will use HTML5 for this SASsession.""")
       varcat = l2[2].split("\n", nvars)
       del varcat[nvars]
 
-      if self.sascfg.ssh or self._sb.m5dsbug01:
+      if self.sascfg.ssh or self._sb.m5dsbug:
          try:
             sock = socks.socket()
             if self.sascfg.tunnel:
@@ -1973,14 +1971,14 @@ Will use HTML5 for this SASsession.""")
          else:
             host = 'localhost'
          enc  = 'utf_8'
-         if self._sb.m5dsbug01:
+         if self._sb.m5dsbug:
             code = "filename sock socket '"+host+":"+str(port)+"' lrecl="+str(self.sascfg.lrecl)+" recfm=v termstr=LF;\n"
          else:
             code = "filename sock socket '"+host+":"+str(port)+"' lrecl=1 recfm=f encoding=binary;\n"
       else:
          host = ''
          enc  = self.sascfg.encoding
-         if self._sb.m5dsbug01:
+         if self._sb.m5dsbug:
             code = "filename sock        '"+tmpcsv            +"' lrecl="+str(self.sascfg.lrecl)+" recfm=v termstr=LF;\n"
          else:
             code = "filename sock        '"+tmpcsv            +"' lrecl=1 recfm=f encoding=binary;\n"
@@ -2006,7 +2004,7 @@ Will use HTML5 for this SASsession.""")
             if i % 10 == 0:
                code +='\n'
 
-      if self._sb.m5dsbug01:
+      if self._sb.m5dsbug:
          rsep = colsep+rowsep+'\n'
          code += "file sock dlm="+cdelim+";\nput "
          for i in range(nvars):
@@ -2028,7 +2026,7 @@ Will use HTML5 for this SASsession.""")
                code +='\n'
          code += "run;"
 
-      if self.sascfg.ssh or self._sb.m5dsbug01:
+      if self.sascfg.ssh or self._sb.m5dsbug:
          csv = open(tmpcsv, mode='w')
          sock.listen(1)
          self._asubmit(code, 'text')
@@ -2049,7 +2047,7 @@ Will use HTML5 for this SASsession.""")
                datap = data[0]+data[1]
                datar = data[2]
 
-               if not self._sb.m5dsbug01:
+               if not self._sb.m5dsbug:
                   csv.write(datap.decode(self.sascfg.encoding, errors='replace'))
                else:
                   csv.write(datap.decode(self.sascfg.encoding, errors='replace').replace(rsep,rowsep))


### PR DESCRIPTION
Issue #274 identified a bug in SAS, in the Maintenance 5 (V9.40 M5) which does not have an available hotfix as of yet, that is exposed in the sasdata2datafrmae methods of saspy. The data step code generated by these methods can trigger the bug which results in an infinite loop in SAS data step writing to the file or socket. This is only when running in a multibyte SAS encoding and only in M5. So, I've added an option 'm5dsbug' that can be specified in the configuration definition, or on the SASsession method (set to True or False) to have these saspy methods generate alternate data step code to work around this bug (m5dsbug = True). This code will check if the SASsession is connected to this version of SAS with a multibyte encoding and default to True, if the option hasn't been set in the config or on the session. For the case where there is a hotfix for the bug, and it is applied, setting the value to False will eliminate this alternate behavior. Setting the option (either way) will also eliminate the note written to the output when connecting via SASsession.  