### PR TITLE
Datetimes

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -1078,7 +1078,8 @@ class SASsession():
     def df2sd(self, df: 'pandas.DataFrame', table: str = '_df', libref: str = '',
               results: str = '', keep_outer_quotes: bool = False,
                                  embedded_newlines: bool = False, 
-              LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03') -> 'SASdata':
+              LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+              datetimes: dict={}) -> 'SASdata':
         """
         This is an alias for 'dataframe2sasdata'. Why type all that?
 
@@ -1091,14 +1092,17 @@ class SASsession():
         :param LF: if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to hex(1)
         :param CR: if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to hex(2)
         :param colsep: the column seperator character used for streaming the delimmited data to SAS defaults to hex(3)
+        :param datetimes: dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
         :return: SASdata object
         """
-        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines, LF, CR, colsep)
+        return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines, 
+                                      LF, CR, colsep, datetimes)
 
     def dataframe2sasdata(self, df: 'pandas.DataFrame', table: str = '_df', libref: str = '', 
                           results: str = '', keep_outer_quotes: bool = False,
                                              embedded_newlines: bool = False, 
-                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03') -> 'SASdata':
+                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                          datetimes: dict={}) -> 'SASdata':
         """
         This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
 
@@ -1111,6 +1115,7 @@ class SASsession():
         :param LF: if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to hex(1) 
         :param CR: if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to hex(2) 
         :param colsep: the column seperator character used for streaming the delimmited data to SAS defaults to hex(3) 
+        :param datetimes: dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
         :return: SASdata object
         """
         if self.sascfg.pandas:
@@ -1127,7 +1132,8 @@ class SASsession():
             print("too complicated to show the code, read the source :), sorry.")
             return None
         else:
-            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines, LF, CR, colsep)
+            self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines, 
+                                       LF, CR, colsep, datetimes)
 
         if self.exist(table, libref):
             return SASdata(self, libref, table, results)

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -1079,7 +1079,7 @@ class SASsession():
               results: str = '', keep_outer_quotes: bool = False,
                                  embedded_newlines: bool = False, 
               LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
-              datetimes: dict={}) -> 'SASdata':
+              datetimes: dict={}, outfmts: dict={}) -> 'SASdata':
         """
         This is an alias for 'dataframe2sasdata'. Why type all that?
 
@@ -1093,16 +1093,17 @@ class SASsession():
         :param CR: if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to hex(2)
         :param colsep: the column seperator character used for streaming the delimmited data to SAS defaults to hex(3)
         :param datetimes: dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
+        :param outfmts: dict with column names and formats to assign to the new SAS data set
         :return: SASdata object
         """
         return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines, 
-                                      LF, CR, colsep, datetimes)
+                                      LF, CR, colsep, datetimes, outfmts)
 
     def dataframe2sasdata(self, df: 'pandas.DataFrame', table: str = '_df', libref: str = '', 
                           results: str = '', keep_outer_quotes: bool = False,
                                              embedded_newlines: bool = False, 
                           LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
-                          datetimes: dict={}) -> 'SASdata':
+                          datetimes: dict={}, outfmts: dict={}) -> 'SASdata':
         """
         This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
 
@@ -1116,6 +1117,7 @@ class SASsession():
         :param CR: if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to hex(2) 
         :param colsep: the column seperator character used for streaming the delimmited data to SAS defaults to hex(3) 
         :param datetimes: dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
+        :param outfmts: dict with column names and formats to assign to the new SAS data set
         :return: SASdata object
         """
         if self.sascfg.pandas:
@@ -1133,7 +1135,7 @@ class SASsession():
             return None
         else:
             self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines, 
-                                       LF, CR, colsep, datetimes)
+                                       LF, CR, colsep, datetimes, outfmts)
 
         if self.exist(table, libref):
             return SASdata(self, libref, table, results)

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -633,7 +633,7 @@ class SASSessionCOM(object):
                           libref: str ="", keep_outer_quotes: bool=False,
                                            embedded_newlines: bool=False,
                           LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
-                          datetimes: dict={}):
+                          datetimes: dict={}, outfmts: dict={}):
         """
         Create a SAS dataset from a pandas data frame.
         :param df [pd.DataFrame]: Pandas data frame containing data to write.
@@ -647,6 +647,7 @@ class SASSessionCOM(object):
         CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
         colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
         datetimes - not implemented yet in this access method
+        outfmts - not implemented yet in this access method
         """
         DATETIME_NAME = 'DATETIME26.6'
         DATETIME_FMT = '%Y-%m-%dT%H:%M:%S.%f'

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -632,7 +632,8 @@ class SASSessionCOM(object):
     def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a',
                           libref: str ="", keep_outer_quotes: bool=False,
                                            embedded_newlines: bool=False,
-                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03'):
+                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                          datetimes: dict={}):
         """
         Create a SAS dataset from a pandas data frame.
         :param df [pd.DataFrame]: Pandas data frame containing data to write.
@@ -645,6 +646,7 @@ class SASSessionCOM(object):
         LF - if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to '\x01'
         CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
         colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
+        datetimes - not implemented yet in this access method
         """
         DATETIME_NAME = 'DATETIME26.6'
         DATETIME_FMT = '%Y-%m-%dT%H:%M:%S.%f'

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1045,7 +1045,8 @@ class SASsessionHTTP():
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
                          libref: str ="", keep_outer_quotes: bool=False,
                                           embedded_newlines: bool=False,
-                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03'):
+                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                         datetimes: dict={}):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1056,6 +1057,7 @@ class SASsessionHTTP():
       LF - if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to '\x01'
       CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
       colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
+      datetimes - dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
       '''
       input  = ""
       xlate  = ""
@@ -1067,9 +1069,11 @@ class SASsessionHTTP():
       lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
       cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
       delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
+      dtkeys = datetimes.keys()
 
       for name in range(ncols):
-         input += "'"+str(df.columns[name])+"'n "
+         colname = str(df.columns[name])
+         input  += "'"+colname+"'n "
          if df.dtypes[df.columns[name]].kind in ('O','S','U','V'):
             try:
                col_l = df[df.columns[name]].astype(str).apply(self._getbytelen).max()
@@ -1079,21 +1083,33 @@ class SASsessionHTTP():
                return None
             if col_l == 0:
                col_l = 8
-            length += " '"+str(df.columns[name])+"'n $"+str(col_l)
+            length += " '"+colname+"'n $"+str(col_l)
             if keep_outer_quotes:
                input  += "~ "
             dts.append('C')
             if embedded_newlines:
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, "+lf+");\n "
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, "+cr+");\n "
+               xlate += " '"+colname+"'n = translate('"+colname+"'n, '0A'x, "+lf+");\n"
+               xlate += " '"+colname+"'n = translate('"+colname+"'n, '0D'x, "+cr+");\n"
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
-               length += " '"+str(df.columns[name])+"'n 8"
-               input  += ":E8601DT26.6 "
-               format += "'"+str(df.columns[name])+"'n E8601DT26.6 "
+               length += " '"+colname+"'n 8"
+               input  += ":B8601DT26.6 "
+               if colname not in dtkeys:
+                  format += "'"+colname+"'n E8601DT26.6 "
+               else:
+                  if datetimes[colname].lower() == 'date':
+                     format += "'"+colname+"'n E8601DA. "
+                     xlate  += " '"+colname+"'n = datepart('"+colname+"'n);\n"
+                  else:
+                     if datetimes[colname].lower() == 'time':
+                        format += "'"+colname+"'n E8601TM. "
+                        xlate  += " '"+colname+"'n = timepart('"+colname+"'n);\n"
+                     else:
+                        print("invalid value for datetimes for column "+colname+". Using default.")
+                        format += "'"+colname+"'n E8601DT26.6 "
                dts.append('D')
             else:
-               length += " '"+str(df.columns[name])+"'n 8"
+               length += " '"+colname+"'n 8"
                if df.dtypes[df.columns[name]] == 'bool':
                   dts.append('B')
                else:

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1402,7 +1402,7 @@ Will use HTML5 for this SASsession.""")
                          libref: str ="", keep_outer_quotes: bool=False,
                                           embedded_newlines: bool=False,
                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
-                         datetimes: dict={}):
+                         datetimes: dict={}, outfmts: dict={}):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1414,18 +1414,20 @@ Will use HTML5 for this SASsession.""")
       CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
       colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
       datetimes - dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
+      outfmts - dict with column names and formats to assign to the new SAS data set
       """
-      input  = ""
-      xlate  = ""
-      card   = ""
-      format = ""
-      length = ""
-      dts    = []
-      ncols  = len(df.columns)
-      lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
-      cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
-      delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
-      dtkeys = datetimes.keys()
+      input   = ""
+      xlate   = ""
+      card    = ""
+      format  = ""
+      length  = ""
+      dts     = []
+      ncols   = len(df.columns)
+      lf      = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
+      cr      = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
+      delim   = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
+      dtkeys  = datetimes.keys()
+      fmtkeys = outfmts.keys()
 
       for name in range(ncols):
          colname = str(df.columns[name])
@@ -1451,21 +1453,35 @@ Will use HTML5 for this SASsession.""")
                length += " '"+colname+"'n 8"
                input  += ":B8601DT26.6 "
                if colname not in dtkeys:
-                  format += "'"+colname+"'n E8601DT26.6 "
+                  if colname in fmtkeys:
+                     format += "'"+colname+"'n "+outfmts[colname]+" "
+                  else:
+                     format += "'"+colname+"'n E8601DT26.6 "
                else:
                   if datetimes[colname].lower() == 'date':
-                     format += "'"+colname+"'n E8601DA. "
+                     if colname in fmtkeys:
+                        format += "'"+colname+"'n "+outfmts[colname]+" "
+                     else:
+                        format += "'"+colname+"'n E8601DA. "
                      xlate  += " '"+colname+"'n = datepart('"+colname+"'n);\n"
                   else:
                      if datetimes[colname].lower() == 'time':
-                        format += "'"+colname+"'n E8601TM. "
+                        if colname in fmtkeys:
+                           format += "'"+colname+"'n "+outfmts[colname]+" "
+                        else:
+                           format += "'"+colname+"'n E8601TM. "
                         xlate  += " '"+colname+"'n = timepart('"+colname+"'n);\n"
                      else:
                         print("invalid value for datetimes for column "+colname+". Using default.")
-                        format += "'"+colname+"'n E8601DT26.6 "
+                        if colname in fmtkeys:
+                           format += "'"+colname+"'n "+outfmts[colname]+" "
+                        else:
+                           format += "'"+colname+"'n E8601DT26.6 "
                dts.append('D')
             else:
                length += " '"+colname+"'n 8"
+               if colname in fmtkeys:
+                  format += "'"+colname+"'n "+outfmts[colname]+" "
                if df.dtypes[df.columns[name]] == 'bool':
                   dts.append('B')
                else:

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1579,7 +1579,7 @@ Will use HTML5 for this SASsession.""")
       topts['firstobs'] = ''
    
       code  = "data work._n_u_l_l_;output;run;\n"
-      code += "data _null_; set "+tabname+self._sb._dsopts(topts)+" work._n_u_l_l_;put 'FMT_CATS=';\n"
+      code += "data _null_; set work._n_u_l_l_ "+tabname+self._sb._dsopts(topts)+";put 'FMT_CATS=';\n"
    
       for i in range(nvars):
          code += "_tom = vformatn('"+varlist[i]+"'n);put _tom;\n"
@@ -1814,7 +1814,7 @@ Will use HTML5 for this SASsession.""")
       topts['firstobs'] = ''
 
       code  = "data work._n_u_l_l_;output;run;\n"
-      code += "data _null_; set "+tabname+self._sb._dsopts(topts)+" work._n_u_l_l_;put 'FMT_CATS=';\n"
+      code += "data _null_; set work._n_u_l_l_ "+tabname+self._sb._dsopts(topts)+";put 'FMT_CATS=';\n"
 
       for i in range(nvars):
          code += "_tom = vformatn('"+varlist[i]+"'n);put _tom;\n"
@@ -2053,7 +2053,7 @@ Will use HTML5 for this SASsession.""")
       topts['firstobs'] = ''
 
       code  = "data work._n_u_l_l_;output;run;\n"
-      code += "data _null_; set "+tabname+self._sb._dsopts(topts)+" work._n_u_l_l_;put 'FMT_CATS=';\n"
+      code += "data _null_; set work._n_u_l_l_ "+tabname+self._sb._dsopts(topts)+";put 'FMT_CATS=';\n"
 
       for i in range(nvars):
          code += "_tom = vformatn('"+varlist[i]+"'n);put _tom;\n"

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1401,7 +1401,8 @@ Will use HTML5 for this SASsession.""")
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
                          libref: str ="", keep_outer_quotes: bool=False,
                                           embedded_newlines: bool=False,
-                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03'):
+                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                         datetimes: dict={}):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1412,6 +1413,7 @@ Will use HTML5 for this SASsession.""")
       LF - if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to '\x01'
       CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
       colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
+      datetimes - dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
       """
       input  = ""
       xlate  = ""
@@ -1423,9 +1425,11 @@ Will use HTML5 for this SASsession.""")
       lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
       cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
       delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
+      dtkeys = datetimes.keys()
 
       for name in range(ncols):
-         input += "'"+str(df.columns[name])+"'n "
+         colname = str(df.columns[name])
+         input  += "'"+colname+"'n "
          if df.dtypes[df.columns[name]].kind in ('O','S','U','V'):
             try:
                col_l = df[df.columns[name]].astype(str).apply(self._getbytelen).max()
@@ -1435,21 +1439,33 @@ Will use HTML5 for this SASsession.""")
                return None
             if col_l == 0:
                col_l = 8
-            length += " '"+str(df.columns[name])+"'n $"+str(col_l)
+            length += " '"+colname+"'n $"+str(col_l)
             if keep_outer_quotes:
                input  += "~ "
             dts.append('C')
             if embedded_newlines:
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, "+lf+");\n "
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, "+cr+");\n "
+               xlate += " '"+colname+"'n = translate('"+colname+"'n, '0A'x, "+lf+");\n"
+               xlate += " '"+colname+"'n = translate('"+colname+"'n, '0D'x, "+cr+");\n"
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
-               length += " '"+str(df.columns[name])+"'n 8"
-               input  += ":E8601DT26.6 "
-               format += "'"+str(df.columns[name])+"'n E8601DT26.6 "
+               length += " '"+colname+"'n 8"
+               input  += ":B8601DT26.6 "
+               if colname not in dtkeys:
+                  format += "'"+colname+"'n E8601DT26.6 "
+               else:
+                  if datetimes[colname].lower() == 'date':
+                     format += "'"+colname+"'n E8601DA. "
+                     xlate  += " '"+colname+"'n = datepart('"+colname+"'n);\n"
+                  else:
+                     if datetimes[colname].lower() == 'time':
+                        format += "'"+colname+"'n E8601TM. "
+                        xlate  += " '"+colname+"'n = timepart('"+colname+"'n);\n"
+                     else:
+                        print("invalid value for datetimes for column "+colname+". Using default.")
+                        format += "'"+colname+"'n E8601DT26.6 "
                dts.append('D')
             else:
-               length += " '"+str(df.columns[name])+"'n 8"
+               length += " '"+colname+"'n 8"
                if df.dtypes[df.columns[name]] == 'bool':
                   dts.append('B')
                else:

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1783,7 +1783,7 @@ Will use HTML5 for this SASsession.""")
       topts['firstobs'] = ''
 
       code  = "data work._n_u_l_l_;output;run;\n"
-      code += "data _null_; file STDERR; set "+tabname+self._sb._dsopts(topts)+" work._n_u_l_l_;put 'FMT_CATS=';\n"
+      code += "data _null_; file STDERR; set work._n_u_l_l_ "+tabname+self._sb._dsopts(topts)+";put 'FMT_CATS=';\n"
 
       for i in range(nvars):
          code += "_tom = vformatn('"+varlist[i]+"'n);put _tom;\n"
@@ -1984,7 +1984,7 @@ Will use HTML5 for this SASsession.""")
       topts['firstobs'] = ''
 
       code  = "data work._n_u_l_l_;output;run;\n"
-      code += "data _null_; file STDERR; set "+tabname+self._sb._dsopts(topts)+" work._n_u_l_l_;put 'FMT_CATS=';\n"
+      code += "data _null_; file STDERR; set work._n_u_l_l_ "+tabname+self._sb._dsopts(topts)+";put 'FMT_CATS=';\n"
 
       for i in range(nvars):
          code += "_tom = vformatn('"+varlist[i]+"'n);put _tom;\n"

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1544,7 +1544,7 @@ Will use HTML5 for this SASsession.""")
       topts['firstobs'] = ''
       
       code  = "data work._n_u_l_l_;output;run;\n"
-      code += "data _null_; file STDERR; set "+tabname+self._sb._dsopts(topts)+" work._n_u_l_l_;put 'FMT_CATS=';\n"
+      code += "data _null_; file STDERR; set work._n_u_l_l_ "+tabname+self._sb._dsopts(topts)+";put 'FMT_CATS=';\n"
 
       for i in range(nvars):
          code += "_tom = vformatn('"+varlist[i]+"'n);put _tom;\n"

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1362,7 +1362,7 @@ Will use HTML5 for this SASsession.""")
                          libref: str ="", keep_outer_quotes: bool=False,
                                           embedded_newlines: bool=False,
                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
-                         datetimes: dict={}):
+                         datetimes: dict={}, outfmts: dict={}):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1374,18 +1374,20 @@ Will use HTML5 for this SASsession.""")
       CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
       colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
       datetimes - dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
+      outfmts - dict with column names and formats to assign to the new SAS data set
       """
-      input  = ""
-      xlate  = ""
-      card   = ""
-      format = ""
-      length = ""
-      dts    = []
-      ncols  = len(df.columns)
-      lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
-      cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
-      delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
-      dtkeys = datetimes.keys()
+      input   = ""
+      xlate   = ""
+      card    = ""
+      format  = ""
+      length  = ""
+      dts     = []
+      ncols   = len(df.columns)
+      lf      = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
+      cr      = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
+      delim   = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
+      dtkeys  = datetimes.keys()
+      fmtkeys = outfmts.keys()
 
       for name in range(ncols):
          colname = str(df.columns[name])
@@ -1400,6 +1402,8 @@ Will use HTML5 for this SASsession.""")
             if col_l == 0:
                col_l = 8
             length += " '"+colname+"'n $"+str(col_l)
+            if colname in fmtkeys:
+               format += "'"+colname+"'n "+outfmts[colname]+" "
             if keep_outer_quotes:
                input  += "~ "
             dts.append('C')
@@ -1411,21 +1415,35 @@ Will use HTML5 for this SASsession.""")
                length += " '"+colname+"'n 8"
                input  += ":B8601DT26.6 "
                if colname not in dtkeys:
-                  format += "'"+colname+"'n E8601DT26.6 "
+                  if colname in fmtkeys:
+                     format += "'"+colname+"'n "+outfmts[colname]+" "
+                  else:
+                     format += "'"+colname+"'n E8601DT26.6 "
                else:
                   if datetimes[colname].lower() == 'date':
-                     format += "'"+colname+"'n E8601DA. "
+                     if colname in fmtkeys:
+                        format += "'"+colname+"'n "+outfmts[colname]+" "
+                     else:
+                        format += "'"+colname+"'n E8601DA. "
                      xlate  += " '"+colname+"'n = datepart('"+colname+"'n);\n"
                   else:
                      if datetimes[colname].lower() == 'time':
-                        format += "'"+colname+"'n E8601TM. "
+                        if colname in fmtkeys:
+                           format += "'"+colname+"'n "+outfmts[colname]+" "
+                        else:
+                           format += "'"+colname+"'n E8601TM. "
                         xlate  += " '"+colname+"'n = timepart('"+colname+"'n);\n"
                      else:
                         print("invalid value for datetimes for column "+colname+". Using default.")
-                        format += "'"+colname+"'n E8601DT26.6 "
+                        if colname in fmtkeys:
+                           format += "'"+colname+"'n "+outfmts[colname]+" "
+                        else:
+                           format += "'"+colname+"'n E8601DT26.6 "
                dts.append('D')
             else:
                length += " '"+colname+"'n 8"
+               if colname in fmtkeys:
+                  format += "'"+colname+"'n "+outfmts[colname]+" "
                if df.dtypes[df.columns[name]] == 'bool':
                   dts.append('B')
                else:

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1361,7 +1361,8 @@ Will use HTML5 for this SASsession.""")
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a',
                          libref: str ="", keep_outer_quotes: bool=False,
                                           embedded_newlines: bool=False,
-                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03'):
+                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                         datetimes: dict={}):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1372,6 +1373,7 @@ Will use HTML5 for this SASsession.""")
       LF - if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to '\x01'
       CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
       colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
+      datetimes - dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
       """
       input  = ""
       xlate  = ""
@@ -1383,9 +1385,11 @@ Will use HTML5 for this SASsession.""")
       lf     = "'"+'%02x' % ord(LF.encode(self.sascfg.encoding))+"'x"
       cr     = "'"+'%02x' % ord(CR.encode(self.sascfg.encoding))+"'x "
       delim  = "'"+'%02x' % ord(colsep.encode(self.sascfg.encoding))+"'x "
+      dtkeys = datetimes.keys()
 
       for name in range(ncols):
-         input += "'"+str(df.columns[name])+"'n "
+         colname = str(df.columns[name])
+         input  += "'"+colname+"'n "
          if df.dtypes[df.columns[name]].kind in ('O','S','U','V'):
             try:
                col_l = df[df.columns[name]].astype(str).apply(self._getbytelen).max()
@@ -1395,21 +1399,33 @@ Will use HTML5 for this SASsession.""")
                return None
             if col_l == 0:
                col_l = 8
-            length += " '"+str(df.columns[name])+"'n $"+str(col_l)
+            length += " '"+colname+"'n $"+str(col_l)
             if keep_outer_quotes:
                input  += "~ "
             dts.append('C')
             if embedded_newlines:
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0A'x, "+lf+");\n "
-               xlate += "'"+str(df.columns[name])+"'n = translate("+"'"+str(df.columns[name])+"'n, '0D'x, "+cr+");\n "
+               xlate += " '"+colname+"'n = translate('"+colname+"'n, '0A'x, "+lf+");\n"
+               xlate += " '"+colname+"'n = translate('"+colname+"'n, '0D'x, "+cr+");\n"
          else:
             if df.dtypes[df.columns[name]].kind in ('M'):
-               length += " '"+str(df.columns[name])+"'n 8"
+               length += " '"+colname+"'n 8"
                input  += ":B8601DT26.6 "
-               format += "'"+str(df.columns[name])+"'n E8601DT26.6 "
+               if colname not in dtkeys:
+                  format += "'"+colname+"'n E8601DT26.6 "
+               else:
+                  if datetimes[colname].lower() == 'date':
+                     format += "'"+colname+"'n E8601DA. "
+                     xlate  += " '"+colname+"'n = datepart('"+colname+"'n);\n"
+                  else:
+                     if datetimes[colname].lower() == 'time':
+                        format += "'"+colname+"'n E8601TM. "
+                        xlate  += " '"+colname+"'n = timepart('"+colname+"'n);\n"
+                     else:
+                        print("invalid value for datetimes for column "+colname+". Using default.")
+                        format += "'"+colname+"'n E8601DT26.6 "
                dts.append('D')
             else:
-               length += " '"+str(df.columns[name])+"'n 8"
+               length += " '"+colname+"'n 8"
                if df.dtypes[df.columns[name]] == 'bool':
                   dts.append('B')
                else:


### PR DESCRIPTION
Enhancements to df2sd to allow specifying datetimes={} which identifies datetime columns (in the data frame) which should be created in SAS as only date or time. datetimes={'col1' : 'date', 'col2' : 'time'}. The keys are the column (variable) names and 'date' or 'time' are the only valid values.

Also, outfmts={} has been added to allow an easy way to assign formats on the output SAS dataset. The dictionary keys are the column (variable) names, and the values are valid SAS Formats. outfmts={'col1' : 'YYMMDD.', 'col2' : 'TIMEAMPM.', 'some_numeric_col' : 'comma32.4'} 

