### PR TITLE
Quotes

### DIFF
--- a/saspy/sasdata.py
+++ b/saspy/sasdata.py
@@ -1084,6 +1084,18 @@ class SASdata:
                     this has better support than CSV for embedded delimiters (commas), nulls, CR/LF that CSV
                     has problems with 
 
+
+        For the CSV and DISK methods, the following 2 parameters are also available
+        :param tempfile: [optional] an OS path for a file to use for the local file; default it a temporary file that's cleaned up
+        :param tempkeep: if you specify your own file to use with tempfile=, this controls whether it's cleaned up after using it
+
+        For the MEMORY and DISK methods the following 4 parameters are also available, depending upon access method
+        :param rowsep: the row seperator character to use; defaults to hex(1)
+        :param colsep: the column seperator character to use; defaults to hex(2)
+        :param rowrep: the char to convert to for any embedded rowsep chars, defaults to  ' '
+        :param colrep: the char to convert to for any embedded colsep chars, defaults to  ' '
+
+
         :param kwargs: a dictionary. These vary per access method, and are generally NOT needed.
                        They are either access method specific parms or specific pandas parms.
                        See the specific sasdata2dataframe* method in the access method for valid possibilities.
@@ -1127,7 +1139,8 @@ class SASdata:
         return self.to_df(method='CSV', tempfile=tempfile, tempkeep=tempkeep, opts=opts, **kwargs)
 
     def to_df_DISK(self, tempfile: str=None, tempkeep: bool=False, 
-                   rowsep: str = '\x01', colsep: str = '\x02', **kwargs) -> 'pandas.DataFrame':
+                   rowsep: str = '\x01', colsep: str = '\x02',
+                   rowrep: str = ' ',    colrep: str = ' ', **kwargs) -> 'pandas.DataFrame':
         """
         This is an alias for 'to_df' specifying method='DISK'.
 
@@ -1135,6 +1148,8 @@ class SASdata:
         :param tempkeep: if you specify your own file to use with tempfile=, this controls whether it's cleaned up after using it
         :param rowsep: the row seperator character to use; defaults to hex(1)
         :param colsep: the column seperator character to use; defaults to hex(2)
+        :param rowrep: the char to convert to for any embedded rowsep chars, defaults to  ' '
+        :param colrep: the char to convert to for any embedded colsep chars, defaults to  ' '
         :param kwargs: a dictionary. These vary per access method, and are generally NOT needed.
                        They are either access method specific parms or specific pandas parms.
                        See the specific sasdata2dataframe* method in the access method for valid possibilities.
@@ -1142,7 +1157,8 @@ class SASdata:
         :return: Pandas data frame
         :rtype: 'pd.DataFrame'
         """
-        return self.to_df(method='DISK', tempfile=tempfile, tempkeep=tempkeep, rowsep=rowsep, colsep=colsep, **kwargs)
+        return self.to_df(method='DISK', tempfile=tempfile, tempkeep=tempkeep, 
+                          rowsep=rowsep, colsep=colsep, rowrep=rowrep, colrep=colrep, **kwargs)
 
     def to_json(self, pretty: bool = False, sastag: bool = False, **kwargs) -> str:
         """

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -637,8 +637,9 @@ class SASSessionCOM(object):
 
     def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a',
                           libref: str ="", keep_outer_quotes: bool=False,
-                                           embedded_newlines: bool=False,
-                          LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                                           embedded_newlines: bool=True,
+                          LF: str = '\x01', CR: str = '\x02',
+                          colsep: str = '\x03', colrep: str = ' ',
                           datetimes: dict={}, outfmts: dict={}, labels: dict={}):
         """
         Create a SAS dataset from a pandas data frame.
@@ -652,6 +653,7 @@ class SASSessionCOM(object):
         LF - if embedded_newlines=True, the chacter to use for LF when transferring the data; defaults to '\x01'
         CR - if embedded_newlines=True, the chacter to use for CR when transferring the data; defaults to '\x02'
         colsep - the column seperator character used for streaming the delimmited data to SAS defaults to '\x03'
+        colrep - the char to convert to for any embedded colsep, LF, CR chars in the data; defaults to  ' '
         datetimes - not implemented yet in this access method
         outfmts - not implemented yet in this access method
         labels - not implemented yet in this access method
@@ -727,6 +729,13 @@ class SASSessionCOM(object):
         :option tempfile [str]: File path for the saved output file.
         :return [pd.DataFrame]:
         """
+        # strip off unused by this access method options from kwargs
+        # so they can't be passes to panda later
+        rowsep = kwargs.pop('rowsep', ' ')
+        colsep = kwargs.pop('colsep', ' ')
+        rowrep = kwargs.pop('rowrep', ' ')
+        colrep = kwargs.pop('colrep', ' ')
+
         if method.upper() == 'DISK':
            print("This access method doesn't support the DISK method. Try CSV or MEMORY")
            return None

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1127,8 +1127,9 @@ class SASsessionHTTP():
 
    def dataframe2sasdata(self, df: '<Pandas Data Frame object>', table: str ='a', 
                          libref: str ="", keep_outer_quotes: bool=False,
-                                          embedded_newlines: bool=False,
-                         LF: str = '\x01', CR: str = '\x02', colsep: str = '\x03',
+                                          embedded_newlines: bool=True,
+                         LF: str = '\x01', CR: str = '\x02',
+                         colsep: str = '\x03', colrep: str = ' ',
                          datetimes: dict={}, outfmts: dict={}, labels: dict={}):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
@@ -1245,7 +1246,9 @@ class SASsessionHTTP():
                if var == 'nan':
                   var = ' '
                else:
+                  var = var.replace(colsep, colrep)
                   if embedded_newlines:
+                     var = var.replace(LF, colrep).replace(CR, colrep)
                      var = var.replace('\n', LF).replace('\r', CR)
             elif dts[col] == 'B':
                var = str(int(row[col]))
@@ -1267,19 +1270,29 @@ class SASsessionHTTP():
       ll = self.submit("run;", 'text')
       return
 
-   def sasdata2dataframe(self, table: str, libref: str ='', dsopts: dict ={}, **kwargs) -> '<Pandas Data Frame object>':
+   def sasdata2dataframe(self, table: str, libref: str ='', dsopts: dict = None,
+                         rowsep: str = '\x01', colsep: str = '\x02',
+                         rowrep: str = ' ',    colrep: str = ' ',
+                         **kwargs) -> '<Pandas Data Frame object>':
       '''
       This method exports the SAS Data Set to a Pandas Data Frame, returning the Data Frame object.
       table   - the name of the SAS Data Set you want to export to a Pandas Data Frame
       libref  - the libref for the SAS Data Set.
       dsopts  - data set options for the input SAS Data Set
+      Only for DISK version:
+      rowsep  - the row seperator character to use; defaults to '\x01'
+      colsep  - the column seperator character to use; defaults to '\x02'
+      rowrep  - the char to convert to for any embedded rowsep chars, defaults to  ' '
+      colrep  - the char to convert to for any embedded colsep chars, defaults to  ' '
       '''
+      dsopts = dsopts if dsopts is not None else {}
 
       method = kwargs.pop('method', None)
       if   method and method.lower() == 'csv':
          return self.sasdata2dataframeCSV(table, libref, dsopts, **kwargs)
       elif method and method.lower() == 'disk':
-         return self.sasdata2dataframeDISK(table, libref, dsopts, **kwargs)
+         return self.sasdata2dataframeDISK(table, libref, dsopts, rowsep, colsep,
+                                           rowrep, colrep, **kwargs)
 
       my_fmts = kwargs.pop('my_fmts', False)
       k_dts   = kwargs.pop('dtype',   None)
@@ -1364,7 +1377,7 @@ class SASsessionHTTP():
       uri = "/compute/sessions/"+self.pid+"/data/work/saspy_ds2df/rows"
 
       r     = []
-      df    = None
+      df    = pd.DataFrame.from_records(r, columns=varlist)
       trows = kwargs.get('trows', None)
       if not trows:
          trows = 100000
@@ -1578,8 +1591,9 @@ class SASsessionHTTP():
 
       return df
 
-   def sasdata2dataframeDISK(self, table: str, libref: str ='', dsopts: dict ={},
-                             rowsep: str = '\x01', colsep: str = '\x02', tempfile: str=None, 
+   def sasdata2dataframeDISK(self, table: str, libref: str ='', dsopts: dict = None,
+                             rowsep: str = '\x01', colsep: str = '\x02',
+                             rowrep: str = ' ',    colrep: str = ' ', tempfile: str=None, 
                              tempkeep: bool=False, **kwargs) -> '<Pandas Data Frame object>':
       '''
       This method exports the SAS Data Set to a Pandas Data Frame, returning the Data Frame object.
@@ -1588,6 +1602,8 @@ class SASsessionHTTP():
       dsopts   - data set options for the input SAS Data Set
       rowsep   - the row seperator character to use; defaults to '\x01'
       colsep   - the column seperator character to use; defaults to '\x02'
+      rowrep  - the char to convert to for any embedded rowsep chars, defaults to  ' '
+      colrep  - the char to convert to for any embedded colsep chars, defaults to  ' '
       tempfile - file to use to store CSV, else temporary file will be used.
       tempkeep - if you specify your own file to use with tempfile=, this controls whether it's cleaned up after using it
 
@@ -1597,8 +1613,7 @@ class SASsessionHTTP():
       dtype   - this is the parameter to Pandas read_csv, overriding what saspy generates and uses
       my_fmts - bool: if True, overrides the formats saspy would use, using those on the data set or in dsopts=
       '''
-      rowrep = kwargs.pop('rowrep', ' ')
-      colrep = kwargs.pop('colrep', ' ')
+      dsopts = dsopts if dsopts is not None else {}
 
       if libref:
          tabname = libref+".'"+table.strip()+"'n "

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1230,7 +1230,7 @@ class SASsessionHTTP():
       if len(format):
          code += "format "+format+";\n"
       code += label
-      code += "infile datalines delimiter="+delim+" DSD STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
+      code += "infile datalines delimiter="+delim+" STOPOVER;\ninput @;\nif _infile_ = '' then delete;\ninput "+input+";\n"+xlate+";\ndatalines4;"
       self._asubmit(code, "text")
 
       code = ""
@@ -1597,6 +1597,9 @@ class SASsessionHTTP():
       dtype   - this is the parameter to Pandas read_csv, overriding what saspy generates and uses
       my_fmts - bool: if True, overrides the formats saspy would use, using those on the data set or in dsopts=
       '''
+      rowrep = kwargs.pop('rowrep', ' ')
+      colrep = kwargs.pop('colrep', ' ')
+
       if libref:
          tabname = libref+".'"+table.strip()+"'n "
       else:
@@ -1685,8 +1688,20 @@ class SASsessionHTTP():
                if i % 10 == 0:
                   code +='\n'
 
-      code += "file _tomodsx lrecl=1 recfm=f encoding=binary;\n"
-
+      code += "\nfile _tomodsx lrecl=1 recfm=f encoding=binary;\n"
+      for i in range(nvars):
+         if vartype[i] != 'FLOAT':
+            code += "'"+varlist[i]+"'n = translate('"
+            code +=     varlist[i]+"'n, '{}'x, '{}'x); ".format(   \
+                        '%02x%02x' %                               \
+                        (ord(rowrep.encode(self.sascfg.encoding)), \
+                         ord(colrep.encode(self.sascfg.encoding))),
+                        '%02x%02x' %                               \
+                        (ord(rowsep.encode(self.sascfg.encoding)), \
+                         ord(colsep.encode(self.sascfg.encoding))))
+            if i % 10 == 0:
+               code +='\n'
+      code += "\n"
       last  = len(varlist)-1
       for i in range(nvars):
          code += "put '"+varlist[i]+"'n "
@@ -1717,9 +1732,11 @@ class SASsessionHTTP():
 
       miss = ['.', ' ']
 
+      quoting = kwargs.pop('quoting', 3)
+
       df = pd.read_csv(tmpcsv, index_col=False, engine='c', header=None, names=varlist, 
                        sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss,
-                       encoding=self.sascfg.encoding, **kwargs)
+                       encoding=self.sascfg.encoding, quoting=quoting, **kwargs)
 
       if tmpdir:
          tmpdir.cleanup()
@@ -1734,15 +1751,3 @@ class SASsessionHTTP():
                   df[varlist[i]] = pd.to_datetime(df[varlist[i]], errors='coerce')
 
       return df
-
-
-if __name__ == "__main__":
-    startsas()
-
-    submit(sys.argv[1], "text")
-
-    print(_getlog())
-    print(_getlsttxt())
-
-    endsas()
-

--- a/saspy/tests/test_pandas.py
+++ b/saspy/tests/test_pandas.py
@@ -167,3 +167,31 @@ class TestPandasDataFrameIntegration(unittest.TestCase):
         self.assertFalse(os.path.isfile(tmpcsv))
 
         tmpdir.cleanup()
+
+
+    def test_sd2df_DISK(self):
+        """
+        Test method sasdata2dataframe using `method=disk` and arguments
+        """
+
+        data = [[42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0],
+        [42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0],
+        [42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0],
+        [42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0]]
+        df = pd.DataFrame(data)
+
+        sd  = self.sas.df2sd(df, 'quotes')
+
+        df2 = sd.to_df()
+        df3 = sd.to_df_DISK()
+
+        self.assertFalse(False in (df2 == df3))
+
+        cars = self.sas.sasdata('cars','sashelp', results='text')
+        df   = cars.to_df_DISK(colsep='A', rowsep='E', colrep='"', rowrep='?')
+
+        self.assertTrue(df.shape == (428, 15))
+
+
+
+

--- a/saspy/tests/test_pandas.py
+++ b/saspy/tests/test_pandas.py
@@ -174,10 +174,14 @@ class TestPandasDataFrameIntegration(unittest.TestCase):
         Test method sasdata2dataframe using `method=disk` and arguments
         """
 
-        data = [[42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0],
-        [42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0],
-        [42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0],
-        [42.5, '"quoted string"', 'non quoted string',44.4,'"leading quote string','"leading"and embedded string',0]]
+        data = [
+        [442.5, '"quoted\x01 string"', 'non\t\tquoted string',44.4,'"leading quote string',    '"leading"and embed\x0Aded string','''"all' "over' 'the "place"''',0],
+        [132.5, '"quoted\x02 string"', 'non quoted string',   41.4,'"leading quote string',    '"leading"and embed\x0Dded string','''"all' "over' 'the "place"''',20.7],
+        [242.5, '"quoted\x03 string"', 'non quoted string',   42.4,'"leading\t\t quote string','"leading"and embed\x0Aded string','''"all' "over' 'the "place"''',20.8],
+        [342.5, '"quoted\x02 string"', 'non quoted string',   43.4,'"leading quote string',    '"leading"and embed\x0Dded string','''"all' "over' 'the "place"''',10.9],
+        [342.5, "'quoted\x01 string'", 'non quoted string',   43.4,'''"leading'quote string''','"leading"and embed\x0Adedstring"','''"all' "over' 'the "place"''',10.9],
+        ]
+
         df = pd.DataFrame(data)
 
         sd  = self.sas.df2sd(df, 'quotes')
@@ -185,6 +189,8 @@ class TestPandasDataFrameIntegration(unittest.TestCase):
         df2 = sd.to_df()
         df3 = sd.to_df_DISK()
 
+        self.assertTrue(df2.shape == (5, 8))
+        self.assertTrue(df3.shape == (5, 8))
         self.assertFalse(False in (df2 == df3))
 
         cars = self.sas.sasdata('cars','sashelp', results='text')


### PR DESCRIPTION
These changes are to fix some parsing failures on both the SAS and pandas side when transferring data via df2ds and the various sd2df methods. These methods use an algorithm that uses low hex values as the delimiters when transferring raw data values. This eliminates the need to parse and manipulate all of the data, quoting and escaping to values themselves. A bug was found where a leading double quote was causing the parsing to be wrong, as 'csv' type rules override delimiters in that case. This fix addresses that so the delimiters control the parsing (as was always the intent), and the raw data values themselves are transferred without need of manipulation and can have any kind of internal quoting.

This change renders keep_outer_quotes= on df2sd deprecated; it's no longer relevant; it was a partial 'fix' to this problem before it was completely understood. Also, the default for embedded_newlines= is being changed to True from False, so that possible parsing failures from this are eliminated by default, with minor performance addition, while it can still be set to False when necessary.

The addition of a conversion character parameter (rowrep, colrep) for these hex 1, 2 or 3 values used as delimiters and surrogate transfer characters (for embedded_newlines) allow these values, if in the actual character string data to be replaced w/ a blank by default, or any char chosen, perhaps a question mark like is used when transcoding cant'be done (replacement char). This addresses a similar parsing problem if these binary values (hex 1,2,3) were in character string data being transferred. These are neither valid characters nor character formatting characters (line feed, carriage return, tab, bacskspace, ...), but rather raw binary values not render-able as character data, which is why they've always been used as delimiters for these methods.
