### PR TITLE
Outencoding

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -954,15 +954,17 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"'
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight'
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight']
-                              'obs'      :  10
-                              'firstobs' : '12'
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
 
         :return: SASdata object
@@ -1070,16 +1072,19 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"',
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight',
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'],
-                              'obs'      :  10,
-                              'firstobs' : '12',
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
+
 
         :param opts: a dictionary containing any of the following Proc Export options(delimiter, putnames)
 
@@ -1142,7 +1147,8 @@ class SASsession():
                                  embedded_newlines: bool = True, 
               LF: str = '\x01', CR: str = '\x02',
               colsep: str = '\x03', colrep: str = ' ',
-              datetimes: dict={}, outfmts: dict={}, labels: dict={}) -> 'SASdata':
+              datetimes: dict={}, outfmts: dict={}, labels: dict={},
+              outencoding: str = '') -> 'SASdata':
         """
         This is an alias for 'dataframe2sasdata'. Why type all that?
 
@@ -1164,17 +1170,20 @@ class SASsession():
         :param colrep: the char to convert to for any embedded colsep, LF, CR chars in the data; defaults to  ' '
         :param datetimes: dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
         :param outfmts: dict with column names and SAS formats to assign to the new SAS data set
+        :param outencoding: the SAS encoding value to use to write out the table, is not the session encoding.
+
         :return: SASdata object
         """
         return self.dataframe2sasdata(df, table, libref, results, keep_outer_quotes, embedded_newlines, 
-                                      LF, CR, colsep, colrep, datetimes, outfmts, labels)
+                                      LF, CR, colsep, colrep, datetimes, outfmts, labels, outencoding)
 
     def dataframe2sasdata(self, df: 'pandas.DataFrame', table: str = '_df', libref: str = '', 
                           results: str = '', keep_outer_quotes: bool = False,
                                              embedded_newlines: bool = True, 
                           LF: str = '\x01', CR: str = '\x02',
                           colsep: str = '\x03', colrep: str = ' ',
-                          datetimes: dict={}, outfmts: dict={}, labels: dict={}) -> 'SASdata':
+                          datetimes: dict={}, outfmts: dict={}, labels: dict={},
+                          outencoding: str = '') -> 'SASdata':
         """
         This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
 
@@ -1196,6 +1205,8 @@ class SASsession():
         :param colrep: the char to convert to for any embedded colsep, LF, CR chars in the data; defaults to  ' '
         :param datetimes: dict with column names as keys and values of 'date' or 'time' to create SAS date or times instead of datetimes
         :param outfmts: dict with column names and SAS formats to assign to the new SAS data set
+        :param outencoding: the SAS encoding value to use to write out the table, is not the session encoding.
+   
         :return: SASdata object
         """
         if self.sascfg.pandas:
@@ -1213,10 +1224,14 @@ class SASsession():
             return None
         else:
             self._io.dataframe2sasdata(df, table, libref, keep_outer_quotes, embedded_newlines, 
-                                       LF, CR, colsep, colrep, datetimes, outfmts, labels)
+                                       LF, CR, colsep, colrep, datetimes, outfmts, labels, outencoding)
+
+        dsopts = {}
+        if len(outencoding):
+           dsopts['encoding'] = outencoding
 
         if self.exist(table, libref):
-            return SASdata(self, libref, table, results)
+            return SASdata(self, libref, table, results, dsopts)
         else:
             return None
 
@@ -1235,16 +1250,20 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"'
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight'
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight']
-                              'obs'      :  10
-                              'firstobs' : '12'
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
+
+
         :param method: defaults to MEMORY;
 
            - MEMORY the original method. Streams the data over and builds the dataframe on the fly in memory
@@ -1291,16 +1310,20 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"'
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight'
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight']
-                              'obs'      :  10
-                              'firstobs' : '12'
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
+
+
         :param tempfile: [optional] an OS path for a file to use for the local CSV file; default it a temporary file that's cleaned up
         :param tempkeep: if you specify your own file to use with tempfile=, this controls whether it's cleaned up after using it
         :param opts: a dictionary containing any of the following Proc Export options(delimiter, putnames)
@@ -1341,15 +1364,17 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"'
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight'
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight']
-                              'obs'      :  10
-                              'firstobs' : '12'
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
 
         :param tempfile: [optional] an OS path for a file to use for the local file; default it a temporary file that's cleaned up
@@ -1386,15 +1411,17 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"'
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight'
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight']
-                              'obs'      :  10
-                              'firstobs' : '12'
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
 
         :param method: defaults to MEMORY:
@@ -1453,15 +1480,17 @@ class SASsession():
             - obs is a numbers - either string or int
             - first obs is a numbers - either string or int
             - format is a string or dictionary { var: format }
+            - encoding is a string 
 
             .. code-block:: python
 
-                             {'where'    : 'msrp < 20000 and make = "Ford"'
-                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight'
-                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight']
-                              'obs'      :  10
-                              'firstobs' : '12'
-                              'format'  : {'money': 'dollar10', 'time': 'tod5.'}
+                             {'where'    : 'msrp < 20000 and make = "Ford"' ,
+                              'keep'     : 'msrp enginesize Cylinders Horsepower Weight' ,
+                              'drop'     : ['msrp', 'enginesize', 'Cylinders', 'Horsepower', 'Weight'] ,
+                              'obs'      :  10 ,
+                              'firstobs' : '12' ,
+                              'format'   : {'money': 'dollar10', 'time': 'tod5.'} ,
+                              'encoding' : 'latin9'
                              }
         :return: str
         """
@@ -1497,6 +1526,9 @@ class SASsession():
 
                     elif key == 'firstobs':
                         opts += 'firstobs=' + str(dsopts[key]) + ' '
+
+                    elif key == 'encoding':
+                        opts += 'encoding="' + str(dsopts[key]) + '" '
 
                     elif key == 'format':
                         if isinstance(dsopts[key], str):

--- a/saspy/sasiocom.py
+++ b/saspy/sasiocom.py
@@ -640,7 +640,8 @@ class SASSessionCOM(object):
                                            embedded_newlines: bool=True,
                           LF: str = '\x01', CR: str = '\x02',
                           colsep: str = '\x03', colrep: str = ' ',
-                          datetimes: dict={}, outfmts: dict={}, labels: dict={}):
+                          datetimes: dict={}, outfmts: dict={}, labels: dict={},
+                          outencoding: str = ''):
         """
         Create a SAS dataset from a pandas data frame.
         :param df [pd.DataFrame]: Pandas data frame containing data to write.
@@ -657,6 +658,7 @@ class SASSessionCOM(object):
         datetimes - not implemented yet in this access method
         outfmts - not implemented yet in this access method
         labels - not implemented yet in this access method
+        outencoding - not implemented yet in this access method
         """
         DATETIME_NAME = 'DATETIME26.6'
         DATETIME_FMT = '%Y-%m-%dT%H:%M:%S.%f'

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1226,7 +1226,7 @@ class SASsessionHTTP():
       code = "data "
       if len(libref):
          code += libref+"."
-      code += "'"+table.strip()+"'n;\n"
+      code += "'"+table.strip()+"'n"
       if len(outencoding):
          code += '(encoding="'+outencoding+'");\n'
       else:

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1130,7 +1130,8 @@ class SASsessionHTTP():
                                           embedded_newlines: bool=True,
                          LF: str = '\x01', CR: str = '\x02',
                          colsep: str = '\x03', colrep: str = ' ',
-                         datetimes: dict={}, outfmts: dict={}, labels: dict={}):
+                         datetimes: dict={}, outfmts: dict={}, labels: dict={},
+                         outencoding: str = ''):
       '''
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1226,6 +1227,10 @@ class SASsessionHTTP():
       if len(libref):
          code += libref+"."
       code += "'"+table.strip()+"'n;\n"
+      if len(outencoding):
+         code += '(encoding="'+outencoding+'");\n'
+      else:
+         code += ";\n"
       if len(length):
          code += "length "+length+";\n"
       if len(format):

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -1382,7 +1382,7 @@ class SASsessionHTTP():
       uri = "/compute/sessions/"+self.pid+"/data/work/saspy_ds2df/rows"
 
       r     = []
-      df    = pd.DataFrame.from_records(r, columns=varlist)
+      df    = None
       trows = kwargs.get('trows', None)
       if not trows:
          trows = 100000
@@ -1440,7 +1440,8 @@ class SASsessionHTTP():
          for i in range(nvars):
             if vartype[i] == 'FLOAT':
                if varcat[i] not in self._sb.sas_date_fmts + self._sb.sas_time_fmts + self._sb.sas_datetime_fmts:
-                  tdf[varlist[i]] = pd.to_numeric(tdf[varlist[i]], errors='coerce') 
+                  if tdf.dtypes[tdf.columns[i]].kind not in ('f','u','i','b','B','c','?'):
+                     tdf[varlist[i]] = pd.to_numeric(tdf[varlist[i]], errors='coerce') 
                else:
                   tdf[varlist[i]] = pd.to_datetime(tdf[varlist[i]], errors='coerce') 
             else:

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -1433,7 +1433,8 @@ Will use HTML5 for this SASsession.""")
                                           embedded_newlines: bool=True,
                          LF: str = '\x01', CR: str = '\x02',
                          colsep: str = '\x03', colrep: str = ' ',
-                         datetimes: dict={}, outfmts: dict={}, labels: dict={}):
+                         datetimes: dict={}, outfmts: dict={}, labels: dict={},
+                         outencoding: str = ''):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1528,7 +1529,11 @@ Will use HTML5 for this SASsession.""")
       code = "data "
       if len(libref):
          code += libref+"."
-      code += "'"+table.strip()+"'n;\n"
+      code += "'"+table.strip()+"'n"
+      if len(outencoding):
+         code += '(encoding="'+outencoding+'");\n'
+      else:
+         code += ";\n"
       if len(length):
          code += "length "+length+";\n"
       if len(format):

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1410,7 +1410,8 @@ Will use HTML5 for this SASsession.""")
                                           embedded_newlines: bool=True,
                          LF: str = '\x01', CR: str = '\x02',
                          colsep: str = '\x03', colrep: str = ' ',
-                         datetimes: dict={}, outfmts: dict={}, labels: dict={}):
+                         datetimes: dict={}, outfmts: dict={}, labels: dict={},
+                         outencoding: str = ''):
       """
       This method imports a Pandas Data Frame to a SAS Data Set, returning the SASdata object for the new Data Set.
       df      - Pandas Data Frame to import to a SAS Data Set
@@ -1506,6 +1507,10 @@ Will use HTML5 for this SASsession.""")
       if len(libref):
          code += libref+"."
       code += "'"+table.strip()+"'n;\n"
+      if len(outencoding):
+         code += '(encoding="'+outencoding+'");\n'
+      else:
+         code += ";\n"
       if len(length):
          code += "length"+length+";\n"
       if len(format):

--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -1506,7 +1506,7 @@ Will use HTML5 for this SASsession.""")
       code = "data "
       if len(libref):
          code += libref+"."
-      code += "'"+table.strip()+"'n;\n"
+      code += "'"+table.strip()+"'n"
       if len(outencoding):
          code += '(encoding="'+outencoding+'");\n'
       else:


### PR DESCRIPTION
adding the ability to create data sets in an encoding other than session encoding, on df2sd(..., outencoding='sas_encoding_value'). This also adds the 'encoding' key in the dsopts for SASdata objects, which it will use when reading or writing back out again.