### PR TITLE
Validvarname

### DIFF
--- a/saspy/tests/test_pandas.py
+++ b/saspy/tests/test_pandas.py
@@ -199,5 +199,80 @@ class TestPandasDataFrameIntegration(unittest.TestCase):
         self.assertTrue(df.shape == (428, 15))
 
 
+class TestPandasValidVarname(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sas = saspy.SASsession()
+        test_dict = {'Salary 2018': [1],
+                   '2019_Salary $(USD)': [1],
+                   'Really_Long_Variable_Name_To_Shorten': [1],
+                   'Really Long Variable Name To Shorten': [1]}
+        duplicate_dict = {'My String!abc' : [0], 'My String@abc' : [1], 
+                         'My String#abc' : [2], 'My String$abc' : [3], 
+                         'My String%abc': [4], 'My String^abc' : [5], 
+                         'My String&abc' :[6], 'My String*abc' : [7], 
+                         'My String(abc' :[8], 'My String)abc' :[9]}
+
+        cls.duplicate_data = pd.DataFrame.from_dict(duplicate_dict)
+        cls.test_data = pd.DataFrame.from_dict(test_dict)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sas._endsas()
+
+    def test_validvarname_v7(self):
+        """
+        Test method validvarname using `version=v7`.
+        """
+        v7_data = self.sas.validvarname(self.test_data)
+        converted_col_names = list(v7_data.columns)
+        correct_names = ["Salary_2018", "_2019_Salary_USD_", 
+                        "Really_Long_Variable_Name_To_Sh0", "Really_Long_Variable_Name_To_Sh1"]
+        
+        [self.assertIn(name, converted_col_names) for name in correct_names]
+        self.assertEqual(len(correct_names), len(converted_col_names))
+        
+
+    def test_validvarname_v6(self):
+        """
+        Test method validvarname using `version=v6`.
+        """
+        v6_data = self.sas.validvarname(self.duplicate_data, version='v6')
+        converted_col_names = list(v6_data.columns)
+
+        correct_names = ['My_Stri0', 'My_Stri1', 
+                         'My_Stri2', 'My_Stri3', 
+                         'My_Stri4', 'My_Stri5', 
+                         'My_Stri6', 'My_Stri7',
+                         'My_Stri8', 'My_Stri9']
+        
+        [self.assertIn(name, converted_col_names) for name in correct_names]
+        self.assertEqual(len(correct_names), len(converted_col_names))
+    
+    def test_validvarname_upcase(self):
+        """
+        Test method validvarname using `version=upcase`.
+        """
+        upcase_data = self.sas.validvarname(self.test_data, version='upcase')
+        converted_col_names = list(upcase_data.columns)
+        correct_names = ["Salary_2018", "_2019_Salary_USD_", 
+                        "Really_Long_Variable_Name_To_Sh0", "Really_Long_Variable_Name_To_Sh1"]
+        correct_names = [name.upper() for name in correct_names]
+        
+        [self.assertIn(name, converted_col_names) for name in correct_names]
+        self.assertEqual(len(correct_names), len(converted_col_names))
 
 
+    def test_validvarname_any(self):
+        """
+        Test method validvarname using `version=any`.
+        """
+        any_data = self.sas.validvarname(self.test_data, version='any')
+        converted_col_names = list(any_data.columns)
+
+        correct_names = ['Salary 2018',
+                         '2019_Salary $(USD)',
+                         'Really_Long_Variable_Name_To_Sho',
+                         'Really Long Variable Name To Sho']
+        [self.assertIn(name, converted_col_names) for name in correct_names]
+        self.assertEqual(len(correct_names), len(converted_col_names))


### PR DESCRIPTION
Implemented a method in SASsession that converts the column-names of a Pandas DataFrame to SAS compatible column names using the same features as the SAS validvarname option. Supports versions V7, V6, UPCASE, and ANY. Unit tests have been added to test_pandas. 

Signed-off-by: Michael Senter <dmsenter89@gmail.com>
