### PR TITLE
Sets a default for cfgname in SASsession

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -143,7 +143,7 @@ class SASconfig(object):
         # Get Config names. Fallback to empty list.
         configs = getattr(SAScfg, "SAS_config_names", [])
 
-        cfgname = kwargs.get('cfgname', '')
+        cfgname = kwargs.get('cfgname', 'default')
 
         if len(cfgname) == 0:
             if len(configs) == 0:


### PR DESCRIPTION
I found an issue when you have multiple profiles. SASsession will prompt you for a profile name if one is not specified. Since this is different than the behavior when you only have one profile in sascfg.py, I added a default argument for cfgname. If it is not specified, it will default to 'default'. If default does not exist, it will ask for the profile.

    Developer's Certificate of Origin 1.1

    By making a contribution to this project, I certify that:

    (a) The contribution was created in whole or in part by me and I
        have the right to submit it under the open source license
        indicated in the file; or

    (b) The contribution is based upon previous work that, to the best
        of my knowledge, is covered under an appropriate open source
        license and I have the right under that license to submit that
        work with modifications, whether created in whole or in part
        by me, under the same open source license (unless I am
        permitted to submit under a different license), as indicated
        in the file; or

    (c) The contribution was provided directly to me by some other
        person who certified (a), (b) or (c) and I have not modified
        it.

    (d) I understand and agree that this project and the contribution
        are public and that a record of the contribution (including all
        personal information I submit with it, including my sign-off) is
        maintained indefinitely and may be redistributed consistent with
        this project or the open source license(s) involved.

      Signed-off-by: Eric Stein <estein27@gmail.com>