### PR TITLE
Alternative fix for #443 and first part of a fix for #447

### DIFF
--- a/saspy/sasiostdio.py
+++ b/saspy/sasiostdio.py
@@ -838,6 +838,7 @@ Will use HTML5 for this SASsession.""")
       while not done:
          try:
             while True:
+               wait = True
                if os.name == 'nt':
                   try:
                      rc = self.pid.wait(0)
@@ -877,6 +878,7 @@ Will use HTML5 for this SASsession.""")
 
                   if len(lst) > 0:
                      lstf += lst
+                     wait = False
                      if ods and not bof and lstf.count(b"<!DOCTYPE html>") > 0:
                         bof = True
                   else:
@@ -893,6 +895,7 @@ Will use HTML5 for this SASsession.""")
 
                   if len(log) > 0:
                      logf += log
+                     wait = False
 
                   if not bail and logf.count(logcodeo) >= 1:
                       if ods:
@@ -905,6 +908,9 @@ Will use HTML5 for this SASsession.""")
 
                   if not len(log) > 0:
                      break
+
+               if wait:
+                  sleep(0.01)
 
             done = True
 


### PR DESCRIPTION
I suggested to fix #443 by sending the data in chunks and this is how it was fixed. On second thoughts however, I am not sure whether this will prevent hanging in all situations (we probably don't fully understand in which situations exactly the SAS process stops reading from `stdin`). Hence, I think it's better to use a thread for writing. My suggestion is contained in the first commit of this pull request. Feel free to change it or leave it.

The second commit addresses one of the problems mentioned in #447. The problem can be exhibited by the code
```
sas.submit("data _null_; t = sleep(1000, 1); run;")
```
which currently uses all available CPU resources when run in STDIO mode on Linux.

My simple fix simply adds a `sleep(0.01)` if no data was read from the SAS process. Again, feel free to fix it differently.

I will prepare another pull request later to address the remaining part of #447.