### PR TITLE
run_sas: to accept more than one SAS file

### DIFF
--- a/saspy/scripts/run_sas.py
+++ b/saspy/scripts/run_sas.py
@@ -9,6 +9,7 @@ import sys
 
 # Usage:
 # ./run_sas.py -s example_1.sas
+# ./run_sas.py -s example_1.sas example_2.sas
 # ./run_sas.py -s example_1.sas -l out1.log -o out1.lst
 # ./run_sas.py -s example_1.sas -r TEXT
 # ./run_sas.py -s example_1.sas -r HTML

--- a/saspy/scripts/run_sas.py
+++ b/saspy/scripts/run_sas.py
@@ -8,19 +8,19 @@ import os.path
 import sys
 
 # Usage:
-# ./run_sas.py -s example_1.sas 
+# ./run_sas.py -s example_1.sas
 # ./run_sas.py -s example_1.sas -l out1.log -o out1.lst
 # ./run_sas.py -s example_1.sas -r TEXT
-# ./run_sas.py -s example_1.sas -r HTML 
-# ./run_sas.py -s example_1.sas -r htMl -l out2.log -o out2.html 
-# ./run_sas.py -s example_1.sas -r teXt -l out3.log -o out3.lst 
-# ./run_sas.py -s /home/a/b/c/example_1.sas 
+# ./run_sas.py -s example_1.sas -r HTML
+# ./run_sas.py -s example_1.sas -r htMl -l out2.log -o out2.html
+# ./run_sas.py -s example_1.sas -r teXt -l out3.log -o out3.lst
+# ./run_sas.py -s /home/a/b/c/example_1.sas
 # ./run_sas.py -s example_1.sas -r text -l out4.log -o out4.lst -c ssh
- 
+
 
 def main():
     parser = argparse.ArgumentParser(description="It executes SAS code using saspy.")
-    parser.add_argument('-s', '--sas_fname',help='Name of the SAS file to be executed.')
+    parser.add_argument('-s', '--sas_fname',nargs='+',help='Name of the SAS file to be executed.')
     parser.add_argument('-l', '--log_fname', help='Name of the output LOG file name. If not specified then it is the same as the sas_fname with .sas removed and .log added.')
     parser.add_argument('-o', '--lst_fname', help='Name of the output LST file. If not specified then it is the same as the sas_fname with .sas removed and .lst/.html added depending on the results format.')
     parser.add_argument('-r', '--results_format', help='Results format for sas_session.submit(). It may be either TEXT or HTML. If not specified it is TEXT by default. It is case incesensitive.')
@@ -30,20 +30,23 @@ def main():
     if options.sas_fname is None:
         parser.print_help()
         sys.exit(0)
-    elif(not os.path.isfile(options.sas_fname)):
-        print("\nSAS file does not exist\n")
-        sys.exit(0)
-
-    sas_fname = options.sas_fname
+    else:
+        sas_fname = options.sas_fname
+        for sfile in sas_fname:
+            if(not os.path.isfile(sfile)):
+                print("WARNING: SAS file (" + sfile + ") does not exist!")
+        if(not os.path.isfile(sas_fname[-1])):
+            print("\nThe last one of the SAS file(s) must be exist!\n")
+            sys.exit(0)
 
     if options.log_fname is None:
-        log_fname = os.path.splitext(sas_fname)[0] + ".log"
+        log_fname = os.path.splitext(sas_fname[-1])[0] + ".log"
         print("log_fname is " + log_fname )
     else:
         log_fname = options.log_fname
 
     if options.results_format is None:
-        results_format = 'TEXT' 
+        results_format = 'TEXT'
     elif options.results_format.upper() in ('HTML','TEXT'):
         results_format = options.results_format
     else:
@@ -52,19 +55,22 @@ def main():
 
     if options.lst_fname is None:
         if results_format == 'HTML':
-            lst_fname = os.path.splitext(sas_fname)[0] + ".html"
+            lst_fname = os.path.splitext(sas_fname[-1])[0] + ".html"
         else:
-            lst_fname = os.path.splitext(sas_fname)[0] + ".lst"
+            lst_fname = os.path.splitext(sas_fname[-1])[0] + ".lst"
         print("lst_fname is " + lst_fname )
     else:
         lst_fname = options.lst_fname
 
-    sas_file     = open(sas_fname,mode='r')
-    sas_code_txt = sas_file.read()
-    sas_file.close()
+    sas_code_txt = ""
+    for sfile in sas_fname:
+        if(os.path.isfile(sfile)):
+            sas_file     = open(sfile,mode='r')
+            sas_code_txt = sas_code_txt + "\n\n" + sas_file.read()
+            sas_file.close()
 
     if options.cfgname is None:
-        sas_session = saspy.SASsession()   
+        sas_session = saspy.SASsession()
     else:
         sas_session = saspy.SASsession(cfgname=options.cfgname)
 
@@ -80,4 +86,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This PR makes run_sas.py accpect more than one SAS file, e.g., 
- `./run_sas.py -s example_1.sas example_2.sas`
- `./run_sas.py -s autoexec.sas example_2.sas`

saspy or run_sas doesn't honor `autoexec.sas` automatically which is different with SAS V9 in batch mode. Our projects use `autoexec.sas` and a project level setting SAS file to manange project settings. We have to using `%include` in each file if we call `run_sas`. It makes the code complicated and `%include` can't includes the remote file which might not be the updated one.

In case we are using IOM with Workspace server (for example, SAS EG), after the PR, `run_sas` can source local copy files which is different to `%inclue` which source the one the server.

It makes the `run_sas` a kind workable solution using in the task in vscode.