### PR TITLE
Improve Unittest File for STATS Products

### DIFF
--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -402,14 +402,14 @@ class TestSASstat(unittest.TestCase):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("SocioEconomics", "work")
-        b = stat.reg(data=tr, procopts='simple corr')
+        b = stat.factor(data=tr, procopts='simple corr')
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
     def test_factorResult2(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("SocioEconomics", "work")
-        b = stat.reg(data=tr,
+        b = stat.factor(data=tr,
                      procopts='priors=smc msa residual rotate=promax reorder outstat=fact_all',
                      var = ['population', 'school']
                      )

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -143,28 +143,28 @@ class TestSASstat(unittest.TestCase):
              'RESIDUALBYPREDICTED',
              'RESIDUALHISTOGRAM', 'RESIDUALPLOT', 'RFPLOT', 'RSTUDENTBYLEVERAGE', 'RSTUDENTBYPREDICTED']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u"Simple Regession (reg) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (reg) model failed to return correct objects. Expected:{0:s}; returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_regResult1(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         b = stat.reg(data=tr, model='weight=height')
-        self.assertIsInstance(b, saspy.sasresults.SASresults, msg="correct return type")
+        self.assertIsInstance(b, saspy.sasresults.SASresults, msg="Incorrect return type.")
 
     def test_regResult2(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('PANDAS')
         b = stat.reg(data=tr, model='weight=height')
-        self.assertIsInstance(b.ANOVA, pandas.core.frame.DataFrame, msg="correct return type")
+        self.assertIsInstance(b.ANOVA, pandas.core.frame.DataFrame, msg="Incorrect return type.")
 
     def test_regResult3(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('PANDAS')
         b = stat.reg(data=tr, model='weight=height')
-        self.assertIsInstance(b.LOG, IPython.core.display.HTML, msg="correct return type")
+        self.assertIsInstance(b.LOG, IPython.core.display.HTML, msg="Incorrect return type.")
 
     @unittest.skip("Type returns 'NoneType' but correctly displays in Jupyter notebook. This should be looked into more.")
     def test_regResult4(self):
@@ -172,7 +172,7 @@ class TestSASstat(unittest.TestCase):
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('PANDAS')
         b = stat.reg(data=tr, model='weight=height')
-        self.assertIsInstance(b.RESIDUALHISTOGRAM, IPython.core.display.HTML, msg="correct return type")
+        self.assertIsInstance(b.RESIDUALHISTOGRAM, IPython.core.display.HTML, msg="Incorrect return type.")
 
 
     def test_smokeMixed(self):
@@ -183,7 +183,7 @@ class TestSASstat(unittest.TestCase):
         a = ['COVPARMS', 'DIMENSIONS', 'FITSTATISTICS', 'LOG', 'MODELINFO', 'NOBS', 'PEARSONPANEL',
              'RESIDUALPANEL', 'STUDENTPANEL', 'TESTS3']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u" model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u" Mixed failed to return correct objects. Expected:{0:s};  returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_smokeGLM(self):
@@ -194,7 +194,7 @@ class TestSASstat(unittest.TestCase):
         a = ['DIAGNOSTICSPANEL', 'FITPLOT', 'FITSTATISTICS', 'LOG', 'MODELANOVA', 'NOBS', 'OVERALLANOVA',
              'PARAMETERESTIMATES', 'RESIDUALPLOTS']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u" model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u" GLM failed to return correct objects. Expected:{0:s};  returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_smokeLogistic(self):
@@ -202,7 +202,7 @@ class TestSASstat(unittest.TestCase):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         b = stat.logistic(data=tr, model='sex=height weight')
-        self.assertFalse('ERROR_LOG' in b.__dir__(), msg=u"logistic had errors in the log")
+        self.assertFalse('ERROR_LOG' in b.__dir__(), msg=u"Logistic had errors in the log.")
 
     def test_smokeTpspline(self):
         # Basic model returns objects
@@ -230,7 +230,7 @@ class TestSASstat(unittest.TestCase):
         a = ['CRITERIONPLOT', 'DATASUMMARY', 'DIAGNOSTICSPANEL', 'FITPLOT', 'FITSTATISTICS', 'FITSUMMARY', 'LOG',
              'OBSERVEDBYPREDICTED', 'QQPLOT', 'RESIDPANEL', 'RESIDUALBYPREDICTED', 'RESIDUALHISTOGRAM', 'RFPLOT']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u" model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u" TPSPLIE failed to return correct objects. Expected:{0:s}; returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_tpspline2(self):
@@ -261,7 +261,7 @@ class TestSASstat(unittest.TestCase):
              'OBSERVEDBYPREDICTED', 'QQPLOT', 'RESIDPANEL', 'RESIDUALBYPREDICTED', 'RESIDUALHISTOGRAM', 'RFPLOT',
              'SCOREPLOT']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u" model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"TPSPLINE failed to return correct objects. Expected:{0:s}; returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_smokeHPLogistic(self):
@@ -280,7 +280,7 @@ class TestSASstat(unittest.TestCase):
         a = ['ANOVA', 'DATAACCESSINFO', 'DIMENSIONS', 'FITSTATISTICS', 'LOG', 'MODELINFO', 'NOBS',
              'PARAMETERESTIMATES', 'PERFORMANCEINFO']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u"Simple Regession (reg) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (HPREG) model failed to return correct objects. Expected:{0:s}; returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_selectionDict(self):
@@ -293,7 +293,7 @@ class TestSASstat(unittest.TestCase):
              'PARAMETERESTIMATES', 'PERFORMANCEINFO', 'SELECTEDEFFECTS', 'SELECTIONINFO', 'SELECTIONREASON', 
              'SELECTIONSUMMARY', 'STOPREASON']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u"Simple Regession (HPREG) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (HPREG) model failed to return correct objects. Expected:{0:s}; Returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_selectionDict2(self):
@@ -307,7 +307,7 @@ class TestSASstat(unittest.TestCase):
              'MODELINFO', 'NOBS', 'PARAMETERESTIMATES', 'PERFORMANCEINFO', 'SELECTEDEFFECTS', 
              'SELECTIONINFO', 'SELECTIONREASON', 'SELECTIONSUMMARY', 'STOPREASON']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u"Simple Regession (HPREG) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (HPREG) model failed to return correct objects. Expected:{0:s}; Returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_selectionDict3(self):
@@ -321,7 +321,7 @@ class TestSASstat(unittest.TestCase):
              'PARAMETERESTIMATES', 'PERFORMANCEINFO', 'SELECTEDEFFECTS', 'SELECTIONINFO', 'SELECTIONREASON',
              'SELECTIONSUMMARY', 'STOPREASON']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u"Simple Regession (HPREG) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (HPREG) model failed to return correct objects. Expected:{0:s}; Returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_selectionDictError(self):
@@ -333,7 +333,7 @@ class TestSASstat(unittest.TestCase):
         b = stat.hpreg(data=tr, model='weight=height', selection=selDict)
         a = ['ERROR_LOG']
         self.assertEqual(sorted(a), sorted(b.__dir__()),
-                         msg=u"Simple Regession (HPREG) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (HPREG) model failed to return correct objects. Expected:{0:s}; Returned:{1:s}.".format(
                              str(a), str(b)))
 
     def test_missingVar(self):
@@ -342,7 +342,7 @@ class TestSASstat(unittest.TestCase):
         b = stat.mixed(data=tr, weight='novar', model='weight=height')
         a = ['ERROR_LOG']
         self.assertEqual(a, b.__dir__(),
-                         msg=u"Simple Regession (mixed) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
+                         msg=u"Simple Regession (mixed) model failed to return correct objects. Expected:{0:s}; Returned:{1:s}.".format(
                              str(a), str(b)))
     """
     def test_extraStmt(self):
@@ -399,14 +399,14 @@ class TestSASstat(unittest.TestCase):
         tr = self.sas.sasdata("melanoma", "work")
         b = stat.reg(data=tr, model="""Time*VStatus(0)=LogBUN HGB Platelet Age LogWBC
                          Frac LogPBM Protein SCalc / selection=stepwise slentry=0.25 slstay=0.15 details""")
-        self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
+        self.assertIsInstance(b, saspy.SASresults, msg="Incorrect return type")
 
     def test_factorResult1(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("SocioEconomics", "work")
         b = stat.factor(data=tr, procopts='simple corr')
-        self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
+        self.assertIsInstance(b, saspy.SASresults, msg="Incorrect return type")
 
     def test_factorResult2(self):
         stat = self.sas.sasstat()
@@ -416,21 +416,21 @@ class TestSASstat(unittest.TestCase):
                      procopts='priors=smc msa residual rotate=promax reorder outstat=fact_all',
                      var = ['population', 'school']
                      )
-        self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
+        self.assertIsInstance(b, saspy.SASresults, msg="Incorrect return type")
 
     def test_ttestResult1(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("time", "work")
         b = stat.ttest(data=tr, var='time', procopts='h0=80 alpha=0.1')
-        self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
+        self.assertIsInstance(b, saspy.SASresults, msg="Incorrect return type")
 
     def test_ttestResult2(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("pressure", "work")
         b = stat.ttest(data=tr,  paired="SBPbefore*SBPafter")
-        self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
+        self.assertIsInstance(b, saspy.SASresults, msg="Incorrect return type")
 
     def test_strdset1(self):
         stat = self.sas.sasstat()

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -421,14 +421,14 @@ class TestSASstat(unittest.TestCase):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("time", "work")
-        b = stat.reg(data=tr, var='time', procopts='h0=80 alpha=0.1')
+        b = stat.ttest(data=tr, var='time', procopts='h0=80 alpha=0.1')
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
     def test_ttestResult2(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("pressure", "work")
-        b = stat.reg(data=tr,  paired="SBPbefore*SBPafter")
+        b = stat.ttest(data=tr,  paired="SBPbefore*SBPafter")
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
     def test_strdset1(self):

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -436,7 +436,8 @@ class TestSASstat(unittest.TestCase):
         tr = self.sas.sasdata("class", "sashelp")
         s = stat.reg(data='sashelp.class', model='weight=height')
         ds = stat.reg(data=tr, model='weight=height')
-        self.assertEqual(s, ds, msg="string sasdata mismatch")
+        self.assertEqual(len(s._names), len(ds._names), msg="String SASDATA returns different output than SASDATA Object.")
+        pandas.testing.assert_frame_equal(s.FITSTATISTICS, ds.FITSTATISTICS)
 
     @unittest.skip("Test raises 'RecursionError: maximum recursion depth exceeded', but the produced SAS code runs fine when copied staright into SAS.")
     def test_strdset2(self):

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -166,6 +166,7 @@ class TestSASstat(unittest.TestCase):
         b = stat.reg(data=tr, model='weight=height')
         self.assertIsInstance(b.LOG, IPython.core.display.HTML, msg="correct return type")
 
+    @unittest.skip("Type returns 'NoneType' but correctly displays in Jupyter notebook. This should be looked into more.")
     def test_regResult4(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -144,27 +144,27 @@ class TestSASstat(unittest.TestCase):
                          msg=u"Simple Regession (reg) model failed to return correct objects expected:{0:s}  returned:{1:s}".format(
                              str(a), str(b)))
 
-    def regResult1(self):
+    def test_regResult1(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         b = stat.reg(data=tr, model='weight=height')
         self.assertIsInstance(b, saspy.sasresults.SASresults, msg="correct return type")
 
-    def regResult2(self):
+    def test_regResult2(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('PANDAS')
         b = stat.reg(data=tr, model='weight=height')
         self.assertIsInstance(b.ANOVA, pandas.core.frame.DataFrame, msg="correct return type")
 
-    def regResult3(self):
+    def test_regResult3(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('PANDAS')
         b = stat.reg(data=tr, model='weight=height')
         self.assertIsInstance(b.LOG, IPython.core.display.HTML, msg="correct return type")
 
-    def regResult4(self):
+    def test_regResult4(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         tr.set_results('PANDAS')
@@ -390,7 +390,7 @@ class TestSASstat(unittest.TestCase):
         ti5 = stat.glm(data=c, target=t1, input=i3)
         self.assertEqual(m2.__dir__(), ti5.__dir__())
 
-    def phregResult1(self):
+    def test_phregResult1(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("melanoma", "work")
@@ -398,14 +398,14 @@ class TestSASstat(unittest.TestCase):
                          Frac LogPBM Protein SCalc / selection=stepwise slentry=0.25 slstay=0.15 details""")
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
-    def factorResult1(self):
+    def test_factorResult1(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("SocioEconomics", "work")
         b = stat.reg(data=tr, procopts='simple corr')
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
-    def factorResult2(self):
+    def test_factorResult2(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("SocioEconomics", "work")
@@ -415,28 +415,28 @@ class TestSASstat(unittest.TestCase):
                      )
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
-    def ttestResult1(self):
+    def test_ttestResult1(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("time", "work")
         b = stat.reg(data=tr, var='time', procopts='h0=80 alpha=0.1')
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
-    def ttestResult2(self):
+    def test_ttestResult2(self):
         stat = self.sas.sasstat()
         self.defineData()
         tr = self.sas.sasdata("pressure", "work")
         b = stat.reg(data=tr,  paired="SBPbefore*SBPafter")
         self.assertIsInstance(b, saspy.SASresults, msg="correct return type")
 
-    def strdset1(self):
+    def test_strdset1(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         s = stat.reg(data='sashelp.class', model='weight=height')
         ds = stat.reg(data=tr, model='weight=height')
         self.assertEqual(s, ds, msg="string sasdata mismatch")
 
-    def strdset2(self):
+    def test_strdset2(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
         s = stat.reg(data='sashelp.class', model='weight=height')

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -1,7 +1,19 @@
 import unittest
 import saspy
-import pandas
-import IPython
+
+# import Pandas if present
+try:
+    import pandas
+    pd = True
+except:
+    pd = False
+
+# import IPython if present
+try:
+    import IPython
+    ip = True
+except:
+    ip = False
 
 from saspy.tests.util import Utilities
 
@@ -152,6 +164,7 @@ class TestSASstat(unittest.TestCase):
         b = stat.reg(data=tr, model='weight=height')
         self.assertIsInstance(b, saspy.sasresults.SASresults, msg="Incorrect return type.")
 
+    @unittest.skipUnless(pd, "Pandas not installed, skipping DataFrame result check.")
     def test_regResult2(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
@@ -159,6 +172,7 @@ class TestSASstat(unittest.TestCase):
         b = stat.reg(data=tr, model='weight=height')
         self.assertIsInstance(b.ANOVA, pandas.core.frame.DataFrame, msg="Incorrect return type.")
 
+    @unittest.skipUnless(ip, "IPython not installed, skipping HTML return check.")
     def test_regResult3(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")
@@ -432,6 +446,7 @@ class TestSASstat(unittest.TestCase):
         b = stat.ttest(data=tr,  paired="SBPbefore*SBPafter")
         self.assertIsInstance(b, saspy.SASresults, msg="Incorrect return type")
 
+    @unittest.skipUnless(pd, "Pandas not installed, skipping dataframe comparison.")
     def test_strdset1(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -438,6 +438,7 @@ class TestSASstat(unittest.TestCase):
         ds = stat.reg(data=tr, model='weight=height')
         self.assertEqual(s, ds, msg="string sasdata mismatch")
 
+    @unittest.skip("Test raises 'RecursionError: maximum recursion depth exceeded', but the produced SAS code runs fine when copied staright into SAS.")
     def test_strdset2(self):
         stat = self.sas.sasstat()
         tr = self.sas.sasdata("class", "sashelp")

--- a/saspy/tests/test_sasstat.py
+++ b/saspy/tests/test_sasstat.py
@@ -1,5 +1,7 @@
 import unittest
 import saspy
+import pandas
+import IPython
 
 from saspy.tests.util import Utilities
 


### PR DESCRIPTION
Prefixed all tests with `test_` so that they will run with the unittests. This revealed some issues with the tests that I have fixed, including missing imports and tests that called the wrong functions. I also updated the messages to print out a useful error message in the event of a failed test. A skip has been added to `test_regResult4` that deserves further investigation - the test fails due to the function returning a NoneType. When I manually run this scenario in Jupyter, I also get the NoneType _but_ the output displays the HTML correctly as expected. The test `test_strdset2` is skipped because it doesn't seem to function properly. 

This PR fixes #515 .