### PR TITLE
Improved error message when calling 'symget' on a dead session.

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -2093,6 +2093,8 @@ class SASsession():
         ll = self._io.submit("%put " + name + "BEGIN=%symexist(" + name + ") "+ name+"END=;\n")
         l2 = ll['LOG'].rpartition(name + "BEGIN=")[2].rpartition(name+"END=")[0].strip().replace('\n','')
 
+        if l2 == '':
+           raise ValueError("Failed to execute symexist. Your session may have prematurely terminated.")
         var = int(l2)
 
         return bool(var)

--- a/saspy/tests/test_symget.py
+++ b/saspy/tests/test_symget.py
@@ -1,0 +1,18 @@
+import unittest
+import saspy
+
+
+class TestSASViyaML(unittest.TestCase):
+
+    def testSymgetOnDeadSession(self):
+        sas = saspy.SASsession()
+        
+        sas.submit("endsas;")
+
+        try:
+            sas.SYSINFO()
+        except ValueError as e:
+            self.assertFalse(str(e) != "Failed to execute symexist. Your session may have prematurely terminated.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In the current version, symget gets an empty string and then crashes trying to convert it to an int.
In this version it crashes with a helpful error message as to what happened including a guess at the cause that an end-user might understand (that the session is dead).