### PR TITLE
UPDATE: preserve sas timestamps & pass through pyarrow kwargs

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -1857,36 +1857,67 @@ class SASsession():
                                    rowsep, colsep, rowrep, colrep, **kwargs)
 
 
-    def sasdata2parquet(self, parquet_file_path: str, table: str, libref: str ='',
-                        dsopts: dict = None, pa_schema: 'pa.schema' = None,
-                        static_columns:list = None,
-                        partitioned = False, partition_size_mb = 128,
-                        chunk_size_mb = 4, compression = 'snappy',
-                        rowsep: str = '\x01', colsep: str = '\x02',
-                        rowrep: str = ' ',    colrep: str = ' ',
-                        **kwargs) -> None:
+    def sasdata2parquet(self,
+                       parquet_file_path: str, 
+                       table: str, 
+                       libref: str ='',
+                       pa_parquet_kwargs = {"compression": 'snappy',
+                                          "flavor":"spark",
+                                          "write_statistics":False},
+                       pa_pandas_kwargs = {},
+                       partitioned = False, 
+                       partition_size_mb = 128,
+                       chunk_size_mb = 4, 
+                       coerce_timestamp_errors=True,
+                       static_columns:list = None,
+                       dsopts: dict = None, 
+                       rowsep: str = '\x01', 
+                       colsep: str = '\x02',
+                       rowrep: str = ' ',    
+                       colrep: str = ' ',
+                       **kwargs) -> None:
        """
-       This method exports the SAS Data Set to a Parquet file
-       parquet_file_path- path of the parquet file to create
-       table            - the name of the SAS Data Set you want to export to a Pandas Data Frame
-       libref           - the libref for the SAS Data Set.
-       dsopts           - data set options for the input SAS Data Set
-       pa_schema        - an optional pyarrow schema that overrides the default schema
-       static_columns   - optional list of tuples (name, value) representing static columns that will be added to the parquet file.
-       partitioned      - boolean whether the parquet should be writting in partitions
-       partition_size_mb- the size in MB of each partition in memory
-       chunk_size_mb    - the chunk size in MB at which the stream is processes
-       compression      - the compression algorithm for the parquet writer.
-       rowsep           - the row seperator character to use; defaults to '\x01'
-       colsep           - the column seperator character to use; defaults to '\x02'
-       rowrep           - the char to convert to for any embedded rowsep chars, defaults to  ' '
-       colrep           - the char to convert to for any embedded colsep chars, defaults to  ' '
-
-       These two options are for advanced usage. They override how saspy imports data. For more info
-       see https://sassoftware.github.io/saspy/advanced-topics.html#advanced-sd2df-and-df2sd-techniques
-
-       dtype   - this is the parameter to Pandas read_csv, overriding what saspy generates and uses
-       my_fmts - bool: if True, overrides the formats saspy would use, using those on the data set or in dsopts=
+       This method exports the SAS Data Set to a Parquet file.
+       
+       Parameters:
+       -----------
+       parquet_file_path : str
+          Path of the parquet file to create.
+       table : str
+          The name of the SAS Data Set you want to export to a Parquet file.
+       libref : str, optional
+          The libref for the SAS Data Set (default is '').
+       pa_parquet_kwargs : dict, optional
+          Additional parameters to pass to pyarrow.parquet.ParquetWriter 
+          (default is {"compression": 'snappy', "flavor": "spark", "write_statistics": False}).
+       pa_pandas_kwargs : dict, optional
+          Additional parameters to pass to pyarrow.Table.from_pandas (default is {}).
+       partitioned : bool, optional
+          Boolean indicating whether the parquet file should be written in partitions (default is False).
+       partition_size_mb : int, optional
+          The size in MB of each partition in memory (default is 128).
+       chunk_size_mb : int, optional
+          The chunk size in MB at which the stream is processed (default is 4).
+       coerce_timestamp_errors : bool, optional
+          Whether to coerce errors when converting timestamps (default is True).
+       static_columns : list of tuples, optional
+          List of tuples (name, value) representing static columns that will be added to the parquet file (default is None).
+       dsopts : dict, optional
+          Data set options for the input SAS Data Set (default is None).
+       rowsep : str, optional
+          The row separator character to use (default is '\x01').
+       colsep : str, optional
+          The column separator character to use (default is '\x02').
+       rowrep : str, optional
+          The character to convert to for any embedded rowsep chars (default is ' ').
+       colrep : str, optional
+          The character to convert to for any embedded colsep chars (default is ' ').
+       **kwargs : 
+          Additional keyword arguments.
+       
+       Returns:
+       --------
+       None
        """
        lastlog = len(self._io._log)
 
@@ -1902,13 +1933,24 @@ class SASsession():
            print("too complicated to show the code, read the source :), sorry.")
            df = None
        else:
-           df = self._io.sasdata2parquet(parquet_file_path, table, libref, dsopts, pa_schema,
-                                         static_columns, partitioned,  partition_size_mb,
-                                         chunk_size_mb,  compression,
-                                         rowsep, colsep, rowrep, colrep, **kwargs)
-
+           self._io.sasdata2parquet(
+                       parquet_file_path = parquet_file_path, 
+                       table = table, 
+                       libref = libref,
+                       pa_parquet_kwargs = pa_parquet_kwargs,
+                       pa_pandas_kwargs = pa_pandas_kwargs,
+                       partitioned = partitioned, 
+                       partition_size_mb = partition_size_mb,
+                       chunk_size_mb = chunk_size_mb, 
+                       coerce_timestamp_errors=coerce_timestamp_errors,
+                       static_columns = static_columns,
+                       dsopts = dsopts, 
+                       rowsep = rowsep, 
+                       colsep = colsep,
+                       rowrep = rowrep,    
+                       colrep = colrep,
+                       **kwargs)
        self._lastlog = self._io._log[lastlog:]
-       return df
 
     def sd2df_DISK(self, table: str, libref: str = '', dsopts: dict = None, tempfile: str = None,
                   tempkeep: bool = False, rowsep: str = '\x01', colsep: str = '\x02',

--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -23,6 +23,9 @@ import codecs
 import warnings
 import io
 import atexit
+import math
+import shutil
+import datetime
 
 import logging
 logger = logging.getLogger('saspy')
@@ -51,7 +54,7 @@ except ImportError:
 
 try:
    import pyarrow         as pa
-   import pyarrow.csv     as pc
+   import pyarrow.compute as pc
    import pyarrow.parquet as pq
 except ImportError:
    pa = None
@@ -2242,41 +2245,76 @@ Will use HTML5 for this SASsession.""")
 
       return df
 
-   def sasdata2parquet(self, parquet_file_path: str, table: str, libref: str ='',
-                       dsopts: dict = None, pa_schema: 'pa.schema' = None,
+   def sasdata2parquet(self, 
+                       parquet_file_path: str, 
+                       table: str, 
+                       libref: str ='',
+                       pa_parquet_kwargs = {"compression": 'snappy',
+                                          "flavor":"spark",
+                                          "write_statistics":False},
+                       pa_pandas_kwargs = {},
+                       partitioned = False, 
+                       partition_size_mb = 128,
+                       chunk_size_mb = 4, 
+                       coerce_timestamp_errors=True,
                        static_columns:list = None,
-                       partitioned = False, partition_size_mb = 128,
-                       chunk_size_mb = 4, compression = 'snappy',
-                       rowsep: str = '\x01', colsep: str = '\x02',
-                       rowrep: str = ' ',    colrep: str = ' ',
+                       dsopts: dict = None, 
+                       rowsep: str = '\x01', 
+                       colsep: str = '\x02',
+                       rowrep: str = ' ',    
+                       colrep: str = ' ',
                        **kwargs) -> None:
       """
-      This method exports the SAS Data Set to a Parquet file
-      parquet_file_path- path of the parquet file to create
-      table            - the name of the SAS Data Set you want to export to a Pandas Data Frame
-      libref           - the libref for the SAS Data Set.
-      dsopts           - data set options for the input SAS Data Set
-      pa_schema        - an optional pyarrow schema that overrides the default schema
-      static_columns   - optional list of tuples (name, value) representing static columns that will be added to the parquet file.
-      partitioned      - boolean whether the parquet should be writting in partitions
-      partition_size_mb- the size in MB of each partition in memory
-      chunk_size_mb    - the chunk size in MB at which the stream is processes
-      compression      - the compression algorithm for the parquet writer.
-      rowsep           - the row seperator character to use; defaults to '\x01'
-      colsep           - the column seperator character to use; defaults to '\x02'
-      rowrep           - the char to convert to for any embedded rowsep chars, defaults to  ' '
-      colrep           - the char to convert to for any embedded colsep chars, defaults to  ' '
-
-      These two options are for advanced usage. They override how saspy imports data. For more info
-      see https://sassoftware.github.io/saspy/advanced-topics.html#advanced-sd2df-and-df2sd-techniques
-
-      dtype   - this is the parameter to Pandas read_csv, overriding what saspy generates and uses
-      my_fmts - bool: if True, overrides the formats saspy would use, using those on the data set or in dsopts=
+      This method exports the SAS Data Set to a Parquet file.
+      
+      Parameters:
+      -----------
+      parquet_file_path : str
+          Path of the parquet file to create.
+      table : str
+          The name of the SAS Data Set you want to export to a Parquet file.
+      libref : str, optional
+          The libref for the SAS Data Set (default is '').
+      pa_parquet_kwargs : dict, optional
+          Additional parameters to pass to pyarrow.parquet.ParquetWriter 
+          (default is {"compression": 'snappy', "flavor": "spark", "write_statistics": False}).
+      pa_pandas_kwargs : dict, optional
+          Additional parameters to pass to pyarrow.Table.from_pandas (default is {}).
+      partitioned : bool, optional
+          Boolean indicating whether the parquet file should be written in partitions (default is False).
+      partition_size_mb : int, optional
+          The size in MB of each partition in memory (default is 128).
+      chunk_size_mb : int, optional
+          The chunk size in MB at which the stream is processed (default is 4).
+      coerce_timestamp_errors : bool, optional
+          Whether to coerce errors when converting timestamps (default is True).
+      static_columns : list of tuples, optional
+          List of tuples (name, value) representing static columns that will be added to the parquet file (default is None).
+      dsopts : dict, optional
+          Data set options for the input SAS Data Set (default is None).
+      rowsep : str, optional
+          The row separator character to use (default is '\x01').
+      colsep : str, optional
+          The column separator character to use (default is '\x02').
+      rowrep : str, optional
+          The character to convert to for any embedded rowsep chars (default is ' ').
+      colrep : str, optional
+          The character to convert to for any embedded colsep chars (default is ' ').
+      **kwargs : 
+          Additional keyword arguments.
+      
+      Returns:
+      --------
+      None
       """
       if not pa:
          logger.error("pyarrow was not imported. This method can't be used without it.")
          return None
-
+      try:
+         compression = pa_parquet_kwargs["compression"]
+      except KeyError:
+         raise KeyError("The pa_parquet_kwargs dict needs to contain at least the parameter 'compression'. Default value is 'snappy'")
+   
       errors = kwargs.pop('errors', 'strict')
       dsopts = dsopts if dsopts is not None else {}
 
@@ -2433,85 +2471,223 @@ Will use HTML5 for this SASsession.""")
       self.stdin[0].send(b'\ntom says EOL='+logcodeb)
       #self.stdin[0].send(b'\n'+logcodei.encode()+b'\n'+b'tom says EOL='+logcodeb)
 
+      #Define timestamp conversion functions
+      def dt_string_to_float64(pd_series: pd.Series, coerce_timestamp_errors: bool) -> pd.Series:
+         """
+         This function converts a pandas Series of datetime strings to a Series of float64, 
+         handling NaN values and optionally coercing errors to NaN.
+         """
+         
+         if coerce_timestamp_errors:
+            # define conversion with error handling
+            def convert(date_str):
+               try:
+                     return np.datetime64(date_str, 'ms').astype(np.float64)
+               except ValueError:
+                     return np.nan
+            # vectorize for pandas
+            vectorized_convert = np.vectorize(convert, otypes=[np.float64])
+         else:
+            # define conversion without error handling
+            convert = lambda date_str: np.datetime64(date_str, 'ms').astype(np.float64)
+            # vectorize for pandas
+            vectorized_convert = np.vectorize(convert, otypes=[np.float64])
+         
+         result = vectorized_convert(pd_series)
+         
+         return pd.Series(result, index=pd_series.index)
+
+      def dt_string_to_int64(pd_series: pd.Series, coerce_timestamp_errors: bool) -> pd.Series:
+         """
+         This function converts a pandas Series of datetime strings to a Series of Int64, 
+         handling NaN values and optionally coercing errors to NaN.
+         """
+         float64_series = dt_string_to_float64(pd_series, coerce_timestamp_errors)
+         return float64_series.astype('Int64')
+
+      ##### DEFINE SCHEMA #####
+
+      def dts_to_pyarrow_schema(dtype_dict):
+         # Define a mapping from string type names to pyarrow data types
+         type_mapping = {
+            'str': pa.string(),
+            'float': pa.float64(),
+            'int': pa.int64(),
+            'bool': pa.bool_(),
+            'date': pa.date32(),
+            'timestamp': pa.timestamp('ms'),  
+            # python types
+            str: pa.string(),
+            float: pa.float64(),
+            int: pa.int64(),
+            bool: pa.bool_(),
+            datetime.date: pa.timestamp('ms'),
+            datetime.datetime: pa.timestamp('ms'),
+            np.datetime64: pa.timestamp('ms')
+         }
+         
+         # Create a list of pyarrow fields from the dictionary
+         fields = []
+         i=0
+         for column_name, dtype in dtype_dict.items():
+            pa_type = type_mapping.get(dtype)
+            if pa_type is None:
+               logging.warning(f"Unknown data type '{dtype} of column {column_name}. Will try cast to string")
+               pa_type = pa.string()
+         # account for timestamp columns 
+            if vartype[i] == 'N':
+               if varcat[i] in self._sb.sas_date_fmts + self._sb.sas_time_fmts + self._sb.sas_datetime_fmts:
+                  pa_type = pa.timestamp('ms')
+            fields.append(pa.field(column_name, pa_type))
+            i+=1
+         #add static columns to schema, if given
+         if static_columns:
+            for column_name, value in static_columns:
+               py_type = type_mapping.get(type(value))
+               if py_type is None:
+                  logging.warning(f"Unknown data type '{dtype} of column {column_name}. Will try cast to string")
+                  pa_type = pa.string()
+               fields.append(pa.field(column_name, py_type))
+         # Create a pyarrow schema from the list of fields
+         schema = pa.schema(fields)
+         return schema
+      # derive parque schema if not defined by user.
+      if "schema" not in pa_parquet_kwargs or pa_parquet_kwargs["schema"] is None:
+         custom_schema = False
+         pa_parquet_kwargs["schema"] = dts_to_pyarrow_schema(dts)
+      else: 
+         custom_schema = True
+      pa_pandas_kwargs["schema"] = pa_parquet_kwargs["schema"]
+      
+      ##### START STERAM #####
       parquet_writer = None
+      partition = 1
+      loop = 1
+      chunk_size = chunk_size_mb*1024*1024 #convert to bytes
+      data_read = 0
+      rows_read = 0
 
       try:
          sockout = _read_sock(io=self, method='DISK', rsep=(colsep+rowsep+'\n').encode(), rowsep=rowsep.encode(),
-                          lstcodeo=lstcodeo.encode(), logcodeb=logcodeb, errors=errors)
-         logging.info("Socket ready")
-
-         if partitioned:
-            os.makedirs(parquet_file_path)
-
-         partition = 1
-         loop = 1
-         chunk_size = chunk_size_mb*1024*1024 #convert to bytes
-         data_read = 0
-
-         logging.info("Starting stream")
+                              lstcodeo=lstcodeo.encode(), logcodeb=logcodeb)
+         logging.info("Socket ready, waiting for results...")
+         
          # determine how many chunks should be written into one partition.
-         chunks_in_partition = int(partition_size_mb/chunk_size_mb)
+         chunks_in_partition = math.floor(partition_size_mb/chunk_size_mb)
          if chunks_in_partition == 0:
             raise ValueError("Partition size needs to be larger than chunk size")
          while True:
-            # for spark, it is better if large files are split over multiple partitions,
-            # so that all worker nodes can be used to read the data
-            if partitioned:
-               #batch chunks into one partition
-               if loop % chunks_in_partition == 0:
-                  logging.info("Closing partition "+str(partition).zfill(5))
-                  partition += 1
-                  parquet_writer.close()
-                  parquet_writer = None
-               path = f"{parquet_file_path}/{str(partition).zfill(5)}.{compression}.parquet"
-            else:
-               path = parquet_file_path
-            # pyarrow needs \n
+               # 4 MB seems to be the most efficient chunk size, but could vary
 
-            # 4 MB seems to be the most efficient chunk size, but could vary
-            chunk = sockout.read(chunk_size)    #.replace(" "+rowsep,"' '\n"+rowsep) # need to replace empty end of rows
-            if chunk == '':
-               logging.info("Done")
+               chunk = sockout.read(chunk_size)
+               #check if query yields any results
                if loop == 1:
-                  logging.info("Query returned no rows.")
+                  logging.info("Stream ready")
+               if loop == 1 and chunk == '':
+                  logging.warning("Query returned no rows.")
                   return
-               break
+               # create directory if partitioned
+               elif loop == 1 and partitioned:
+                  os.makedirs(parquet_file_path)
+                  
+               if chunk == '':
+                  logging.info("Done")
+                  break
+               # for spark, it is better if large files are split over multiple partitions, 
+               # so that all worker nodes can be used to read the data 
+               if partitioned:
+                  #batch chunks into one partition
+                  if loop % chunks_in_partition == 0: 
+                     logging.info("Closing partition "+str(partition).zfill(5))
+                     partition += 1
+                     parquet_writer.close()
+                     parquet_writer = None
+                  path = f"{parquet_file_path}/{str(partition).zfill(5)}.{compression}.parquet"
+               else:
+                  path = parquet_file_path
 
-            try:
-               df = pd.read_csv(io.StringIO(chunk), index_col=idx_col, engine=eng, header=None, names=dvarlist,
-                   sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss, keep_default_na=False,
-                   encoding='utf-8', quoting=quoting, **kwargs)
-               df = df.astype(dts) # if a column is completely empty, it will be cast as null, so we need to set it (again) here
+               try:
 
-               if static_columns:
-                  df[[col[0] for col in static_columns]] = tuple([col[1] for col in static_columns])
+                  df = pd.read_csv(io.StringIO(chunk), index_col=idx_col, engine=eng, header=None, names=dvarlist,
+                        sep=colsep, lineterminator=rowsep, dtype=dts, na_values=miss,
+                        encoding='utf-8', quoting=quoting, **kwargs) 
 
-               if k_dts is None:  # don't override these if user provided their own dtypes
-                  for i in range(nvars):
-                   if vartype[i] == 'N':
-                      if varcat[i] in self._sb.sas_date_fmts + self._sb.sas_time_fmts + self._sb.sas_datetime_fmts:
-                         df[dvarlist[i]] = pd.to_datetime(df[dvarlist[i]], errors='coerce',unit='ms')#format=timestamp_format
+                  for col in df.columns:
+                     if df[col].isnull().all():
+                        df[col] = df[col].astype(dts[col])
+                        df[col] = np.nan
 
-               pa_table = pa.Table.from_pandas(df,schema=pa_schema)
+                  rows_read += len(df)
+                  if static_columns:
+                     df[[col[0] for col in static_columns]] = tuple([col[1] for col in static_columns])
 
-            except:
-               logging.info(f"Parsing failed, see {path}/failedchunk.csv")
-               os.makedirs(path,exist_ok=True)
-               with open(f"{path}/failedchunk.csv", "w") as log:
-                  log.write(chunk)
-               raise e
+                  if k_dts is None:  # don't override these if user provided their own dtypes
+                     for i in range(nvars):
+                        if vartype[i] == 'N':
+                           if varcat[i] in self._sb.sas_date_fmts + self._sb.sas_time_fmts + self._sb.sas_datetime_fmts:
 
-            if not parquet_writer:
-               parquet_writer = pq.ParquetWriter(path,schema=pa_table.schema,write_statistics = False,compression=compression)#use_deprecated_int96_timestamps=True,
+                              if coerce_timestamp_errors:
+                                 df[dvarlist[i]] = dt_string_to_int64(df[dvarlist[i]],coerce_timestamp_errors)
+                              else:
+                                 try:
+                                    df[dvarlist[i]] = dt_string_to_int64(df[dvarlist[i]],coerce_timestamp_errors)
+                                 except ValueError:
+                                    raise ValueError(f"""The column {dvarlist[i]} contains an unparseable timestamp. 
+   Consider setting a different pd_timestamp_format or set coerce_timestamp_errors = True and they will be cast as Null""")
 
-            # Write the table chunk to the Parquet file
-            parquet_writer.write_table(pa_table)
-            loop += 1
-            data_read += chunk_size
-            if loop % 30 == 0:
-               logging.info(f"{round(data_read/1073741824,2)} GB read so far") #Convert bytes to GB => bytes /1024³
+                  pa_table = pa.Table.from_pandas(df,**pa_pandas_kwargs)
 
-         logging.info(f"Finished reading {round(data_read/1073741824,2)} GB.")
+                  if not custom_schema:
+                     #cast the int64 columns to timestamp
+                     for i in range(nvars):
+                        if vartype[i] == 'N':
+                           if varcat[i] in self._sb.sas_date_fmts + self._sb.sas_time_fmts + self._sb.sas_datetime_fmts:
+                              # Cast the integer column to the timestamp type using pyarrow.compute.cast
+                              casted_column = pc.cast(pa_table[dvarlist[i]], pa.timestamp('ms'))
+                              # Replace int64 with timestamp column
+                              pa_table = pa_table.set_column(pa_table.column_names.index(dvarlist[i]), dvarlist[i], casted_column)
+
+               except Exception as e:
+               #### If parsing a chunk fails, the csv chunk is written to disk and the expression to read the csv using pandas is printed
+                  failed_path= os.path.abspath(path+"_failed")
+                  logging.error(f"Parsing chunk #{loop} failed, see {failed_path}/failedchunk.csv")
+                  if os.path.isdir(failed_path):
+                     shutil.rmtree(failed_path)
+                  os.makedirs(failed_path)
+                  with open(f"{failed_path}/failedchunk.csv", "w",encoding='utf-8') as log:
+                     log.write(chunk)
+                  logging.error(f"""
+   #Read the chunk using:
+   import pandas as pd
+   df = pd.read_csv(
+      '{failed_path}/failedchunk.csv', 
+      index_col={idx_col}, 
+      engine='{eng}', 
+      header=None, 
+      names={dvarlist},
+      sep={colsep!r}, 
+      lineterminator={rowsep!r}, 
+      dtype={dts}, 
+      na_values={miss},
+      encoding='utf-8', 
+      quoting={quoting}, 
+      **{kwargs}
+   )"""           
+                  )
+                  raise e
+               if not parquet_writer:
+                  if "schema" not in pa_parquet_kwargs or pa_parquet_kwargs["schema"] is None:
+                     pa_parquet_kwargs["schema"] = pa_table.schema
+                  parquet_writer = pq.ParquetWriter(path,**pa_parquet_kwargs)#use_deprecated_int96_timestamps=True,
+
+               # Write the table chunk to the Parquet file
+               parquet_writer.write_table(pa_table)
+               loop += 1
+               data_read += chunk_size
+               if loop % 30 == 0:
+                  logging.info(f"{round(data_read/1024/1024/1024,3)} GB / {rows_read} rows read so far") #Convert bytes to GB => bytes /1024³
+         
+         logging.info(f"Finished reading {round(data_read/1024/1024/1024,3)} GB / {rows_read} rows.")
          logging.info(str(pa_table.schema))
       except:
          if os.name == 'nt':


### PR DESCRIPTION
Hello @tomweber-sas ,
I think we closed the testing of our sasdata2parquet staging method (insofar as we have merged this version into our productive workflow, so it should better work as expected haha).

# Preserve original sas timestamps
The main visible change in this version is that the timestamps in the final parquet file will be the timestamps that can be found in sas. This also means, however, that loading the parquet with pandas will lead to OutOfBounds timestamp issue when very large (positive or negative) timestamps are contained in it. 
In this case, the user will need to develop a custom "safely_load_pandas" method that parses the affected columns. But this is still better than just coercing the timestamp to be null by default. Anyways, the raison d'être of the sasdata2parquet method are scenarios where the Data would not fit into memory  and will instead be processed by distributed frameworks like spark.

# Pass through pyarrow kwargs
I further made changes to the parameters. I found wiring individual parameters from the method head to the pyarrow.Table.read_pandas() method or the ParquetWriter class quite constraining for the user. Instead, I give advanced users the ability to pass all possible parameters to these methods using a kwargs dictionary (pa_pandas_kwargs, pa_parquet_kwargs). This accounts for any edge cases that might not be covered in our own workflow and that future users might encounter. We, for example, use it to pass our own pyarrow schema:
```python
sas.sasdata2parquet("test.parquet",table=table,libref=libref,
                             pa_parquet_kwargs = {"schema":pa_schema, "compression": 'snappy',"flavor": "spark","write_statistics": False })
```

There are also some other bug fixes regarding null columns, etc., but the above two are the main "features" relevant to the user.

**IMPORTANT**: Please note that I have developed this method for a client, and my contract will close by the end of this month. This also means that I won't be able to do any more testing (and hence development), since I do not have my own SAS server. I have passed this on to another colleague who will follow your progress on this issue and update the saspy once it is released. If you want me to respond to anythink tht might come out of your tests, it will be able to do so until Wednesday June 26th. Sorry for the short notice.