### PR TITLE
Add duckdb_to_sas() method for fast DuckDB-to-SAS data transfer

### DIFF
--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -1788,6 +1788,248 @@ class SASsession():
         self._lastlog = self._io._log[lastlog:]
         return sd
 
+    def duckdb_to_sas(self, con: 'duckdb.DuckDBPyConnection',
+                      query: str = '',
+                      table: str = '_ddb',
+                      libref: str = '',
+                      results: str = '',
+                      outfmts: dict = {},
+                      labels: dict = {},
+                      outdsopts: dict = {},
+                      char_lengths: dict = {},
+                      datetimes: dict = {},
+                      tempdir: str = '',
+                      tempkeep: bool = False,
+                      **kwargs) -> 'SASdata':
+        """
+        Export a DuckDB query result to a SAS dataset, bypassing pandas.
+
+        Uses DuckDB's native COPY to write a CSV, then submits a generated
+        SAS DATA step to read it. Much faster than df2sd for large datasets
+        because it avoids Python row-by-row serialization.
+
+        :param con: DuckDB connection (duckdb.DuckDBPyConnection)
+        :param query: SQL query or table/view name to export
+        :param table: name of the SAS Data Set to create
+        :param libref: libref for the SAS Data Set. Defaults to WORK, or USER if assigned
+        :param results: format of results, SASsession.results is default, PANDAS, HTML or TEXT
+        :param outfmts: dict with column names and SAS formats to assign
+        :param labels: dict with column names and labels to assign
+        :param outdsopts: dict with output data set options (compress, encoding, etc.)
+        :param char_lengths: dict with column names and character byte lengths. \
+                             Columns not listed are computed via a single DuckDB aggregate query.
+        :param datetimes: dict with column names as keys and 'date' or 'time' as values, \
+                          to override type inference from DuckDB schema
+        :param tempdir: directory for the temporary CSV file. Must be accessible from SAS. \
+                        Defaults to a system temp directory.
+        :param tempkeep: if True, keep the CSV file after import; if False (default), delete it
+
+        :return: SASdata object
+        """
+        lastlog = len(self._io._log)
+
+        try:
+            import duckdb as _duckdb
+        except ImportError:
+            logger.error("duckdb package is not installed. Install it with: pip install duckdb")
+            return None
+
+        if not query:
+            logger.error("query parameter is required")
+            return None
+
+        if libref != '':
+            if libref.upper() not in self.assigned_librefs():
+                logger.error("The libref specified is not assigned in this SAS Session.")
+                return None
+
+        if results == '':
+            results = self.results
+        if self.nosub:
+            print("too complicated to show the code, read the source :), sorry.")
+            return None
+
+        # Normalize query: bare table/view name → SELECT *
+        query_sql = query if ' ' in query.strip() else f"select * from {query}"
+
+        # --- Step 1: Get column schema from DuckDB ---
+        try:
+            col_info = con.execute(f"describe {query_sql} limit 0").df()
+        except Exception as e:
+            logger.error(f"Failed to describe query: {e}")
+            return None
+        col_info.columns = col_info.columns.str.lower()
+
+        col_names = list(col_info['column_name'])
+        col_types = dict(zip(col_info['column_name'], col_info['column_type']))
+
+        # --- Step 2: Classify columns and compute char lengths ---
+        fmt_upper  = {k.upper(): v for k, v in outfmts.items()}
+        lab_upper  = {k.upper(): v for k, v in labels.items()}
+        chr_upper  = {k.upper(): v for k, v in char_lengths.items()}
+        dts_upper  = {k.upper(): v for k, v in datetimes.items()}
+
+        # Identify VARCHAR columns needing length computation
+        unmapped_chars = []
+        for col in col_names:
+            dtype = col_types[col]
+            if dtype in ('VARCHAR', 'CHAR') and col.upper() not in chr_upper:
+                unmapped_chars.append(col)
+
+        # Single aggregate query for all unmapped char column lengths
+        computed_lengths = {}
+        if unmapped_chars:
+            agg_parts = [f"max(length(\"{c}\"))" for c in unmapped_chars]
+            agg_sql = f"select {', '.join(agg_parts)} from ({query_sql})"
+            try:
+                row = con.execute(agg_sql).fetchone()
+                for i, col in enumerate(unmapped_chars):
+                    val = row[i]
+                    computed_lengths[col.upper()] = max(val, 1) if val is not None else 200
+            except Exception:
+                for col in unmapped_chars:
+                    computed_lengths[col.upper()] = 200
+
+        # Merge: explicit char_lengths > computed > fallback 200
+        all_char_lengths = {}
+        for col in col_names:
+            if col_types[col] in ('VARCHAR', 'CHAR'):
+                all_char_lengths[col.upper()] = chr_upper.get(
+                    col.upper(), computed_lengths.get(col.upper(), 200)
+                )
+
+        # --- Step 3: Write CSV via DuckDB COPY ---
+        # Cast BOOLEAN columns to INTEGER so DuckDB writes 1/0 instead of true/false
+        has_bool = any(col_types[c] == 'BOOLEAN' for c in col_names)
+        if has_bool:
+            select_parts = []
+            for col in col_names:
+                if col_types[col] == 'BOOLEAN':
+                    select_parts.append(f"\"{col}\"::integer as \"{col}\"")
+                else:
+                    select_parts.append(f"\"{col}\"")
+            copy_sql = f"select {', '.join(select_parts)} from ({query_sql})"
+        else:
+            copy_sql = query_sql
+
+        if tempdir:
+            csv_dir = tempdir
+            os.makedirs(csv_dir, exist_ok=True)
+        else:
+            csv_dir = tempfile.mkdtemp(prefix='saspy_ddb_')
+
+        csv_path = os.path.join(csv_dir, f'{table}.csv')
+
+        try:
+            con.execute(
+                f"copy ({copy_sql}) to '{csv_path}' "
+                f"(format csv, header true, nullstr '')"
+            )
+        except Exception as e:
+            logger.error(f"DuckDB COPY failed: {e}")
+            return None
+
+        # --- Step 4: Generate SAS DATA step ---
+        length_parts = []
+        format_parts = []
+        label_lines  = []
+        input_parts  = []
+
+        for col in col_names:
+            dtype    = col_types[col]
+            colname  = col.replace("'", "''")
+            col_up   = col.upper()
+
+            # Labels
+            if col_up in lab_upper:
+                label_lines.append(
+                    f"    label '{colname}'n = \"{lab_upper[col_up]}\";"
+                )
+
+            # Formats from metadata
+            if col_up in fmt_upper:
+                format_parts.append(f"'{colname}'n {fmt_upper[col_up]}")
+
+            # Type classification
+            if dtype in ('VARCHAR', 'CHAR'):
+                clen = all_char_lengths.get(col_up, 200)
+                length_parts.append(f"'{colname}'n ${clen}")
+                input_parts.append(f"'{colname}'n : $")
+
+            elif dtype == 'DATE' or (
+                dtype == 'TIMESTAMP' and col_up in dts_upper
+                and dts_upper[col_up].lower() == 'date'
+            ):
+                length_parts.append(f"'{colname}'n 8")
+                input_parts.append(f"'{colname}'n :yymmdd10.")
+                if col_up not in fmt_upper:
+                    format_parts.append(f"'{colname}'n E8601DA.")
+
+            elif dtype == 'TIMESTAMP':
+                length_parts.append(f"'{colname}'n 8")
+                input_parts.append(f"'{colname}'n :ymddttm19.")
+                if col_up not in fmt_upper:
+                    format_parts.append(f"'{colname}'n E8601DT26.6")
+
+            elif dtype == 'BOOLEAN':
+                length_parts.append(f"'{colname}'n 8")
+                input_parts.append(f"'{colname}'n")
+                if col_up not in fmt_upper:
+                    format_parts.append(f"'{colname}'n 1.")
+
+            else:
+                # Numeric: INTEGER, BIGINT, DOUBLE, FLOAT, DECIMAL, etc.
+                length_parts.append(f"'{colname}'n 8")
+                input_parts.append(f"'{colname}'n")
+
+        # Build the DATA step
+        code = "data "
+        if libref:
+            code += libref + "."
+        code += f"'{table}'n"
+
+        if outdsopts:
+            opts = ' '.join(f'{k}={v}' for k, v in outdsopts.items())
+            code += f"({opts})"
+        code += ";\n"
+
+        if length_parts:
+            code += f"    length {' '.join(length_parts)};\n"
+        if format_parts:
+            code += f"    format {' '.join(format_parts)};\n"
+        if label_lines:
+            code += "\n".join(label_lines) + "\n"
+
+        code += f"    infile '{csv_path}' dlm=',' dsd firstobs=2 missover lrecl=1048576;\n"
+        code += f"    input {' '.join(input_parts)};\n"
+        code += "run;\n"
+
+        # --- Step 5: Submit to SAS ---
+        ll = self.submit(code, results='text')
+
+        # Check for errors in log
+        log_text = ll.get('LOG', '')
+        if 'ERROR' in log_text:
+            logger.error(f"SAS errors during duckdb_to_sas import:\n{log_text}")
+
+        # --- Step 6: Clean up CSV ---
+        if not tempkeep:
+            try:
+                os.remove(csv_path)
+                if not tempdir and os.path.isdir(csv_dir) and not os.listdir(csv_dir):
+                    os.rmdir(csv_dir)
+            except OSError:
+                pass
+
+        # --- Step 7: Return SASdata object ---
+        if self.exist(table, libref):
+            sd = SASdata(self, libref, table, results)
+        else:
+            sd = None
+
+        self._lastlog = self._io._log[lastlog:]
+        return sd
+
     def sd2df(self, table: str, libref: str = '', dsopts: dict = None,
               method: str = 'MEMORY', **kwargs) -> 'pandas.DataFrame':
         """

--- a/saspy/tests/test_duckdb.py
+++ b/saspy/tests/test_duckdb.py
@@ -1,0 +1,193 @@
+"""
+Test suite for DuckDB-to-SAS integration.
+
+Tests the duckdb_to_sas() method which exports DuckDB query results
+to SAS datasets via CSV, bypassing pandas serialization.
+
+Requires: duckdb, saspy with an accessible SAS session.
+"""
+
+import unittest
+import tempfile
+import os
+
+import saspy
+
+try:
+    import duckdb
+    DUCKDB_AVAILABLE = True
+except ImportError:
+    DUCKDB_AVAILABLE = False
+
+
+@unittest.skipIf(not DUCKDB_AVAILABLE, "duckdb is not installed")
+class TestDuckDBToSAS(unittest.TestCase):
+    """Test duckdb_to_sas method on SASsession."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sas = saspy.SASsession()
+        cls.sas.set_batch(True)
+        cls.ddb = duckdb.connect()
+
+        # Create test tables in DuckDB
+        cls.ddb.execute("""
+            create table test_mixed as select * from (values
+                (1,  'Alice',   date '1990-01-15', 25.5,  true,  timestamp '2020-06-15 14:30:00'),
+                (2,  'Bob',     date '1985-06-30', 30.0,  false, timestamp '2020-07-20 09:15:30'),
+                (3,  'Carol',   null,              28.7,  true,  null)
+            ) t(id, name, birth_dt, score, active, created_ts)
+        """)
+
+        cls.ddb.execute("""
+            create table test_chars as select * from (values
+                ('00069015001', 'NY', 'paid'),
+                ('35356077330', 'CA', 'denied'),
+                ('68382050010', 'TX', null)
+            ) t(ndc, state_cd, status)
+        """)
+
+        cls.ddb.execute("""
+            create table test_large as
+            select
+                i as id,
+                'member_' || i::varchar as name,
+                date '2020-01-01' + (i % 365)::int as svc_date,
+                (i % 100)::double / 3.0 as amount
+            from generate_series(1, 10000) t(i)
+        """)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ddb.close()
+        cls.sas._endsas()
+
+    def test_duckdb_to_sas_instance(self):
+        """duckdb_to_sas returns a SASdata object."""
+        sd = self.sas.duckdb_to_sas(self.ddb, query='test_mixed', table='ddb_inst')
+        self.assertIsInstance(sd, saspy.sasdata.SASdata)
+
+    def test_duckdb_to_sas_row_count(self):
+        """Correct number of rows transferred."""
+        sd = self.sas.duckdb_to_sas(self.ddb, query='test_mixed', table='ddb_rows')
+        ll = self.sas.submit("proc sql noprint; select count(*) into :n from work.ddb_rows; quit;", results='text')
+        n = int(self.sas.symget('n'))
+        self.assertEqual(n, 3)
+
+    def test_duckdb_to_sas_types(self):
+        """Char, date, numeric, and timestamp columns typed correctly in SAS."""
+        sd = self.sas.duckdb_to_sas(self.ddb, query='test_mixed', table='ddb_types')
+        # Read back via sd2df to check types survived the round trip
+        df = self.sas.sd2df('ddb_types')
+        df.columns = df.columns.str.lower()
+
+        # name should be character (object dtype in pandas)
+        self.assertEqual(df['name'].dtype.kind, 'O')
+        # id should be numeric
+        self.assertIn(df['id'].dtype.kind, ('i', 'f'))
+        # birth_dt should be datetime-like
+        self.assertEqual(df['birth_dt'].dtype.kind, 'M')
+
+    def test_duckdb_to_sas_null_handling(self):
+        """NULL values become SAS missing (NaN/NaT in round-trip)."""
+        sd = self.sas.duckdb_to_sas(self.ddb, query='test_mixed', table='ddb_null')
+        df = self.sas.sd2df('ddb_null')
+        df.columns = df.columns.str.lower()
+
+        # Carol (row 3) has null birth_dt and null created_ts
+        import pandas as pd
+        self.assertTrue(pd.isna(df.loc[2, 'birth_dt']))
+
+    def test_duckdb_to_sas_labels(self):
+        """Labels applied correctly to SAS dataset."""
+        sd = self.sas.duckdb_to_sas(
+            self.ddb, query='test_chars', table='ddb_labels',
+            labels={'ndc': 'National Drug Code', 'state_cd': 'State'},
+        )
+        # Check via proc contents
+        ll = self.sas.submit(
+            "ods listing;\nproc contents data=work.ddb_labels; run;\nods listing close;\n",
+            results='TEXT'
+        )
+        output = ll['LST']
+        self.assertIn('National Drug Code', output)
+        self.assertIn('State', output)
+
+    def test_duckdb_to_sas_formats(self):
+        """Formats applied correctly to SAS dataset."""
+        sd = self.sas.duckdb_to_sas(
+            self.ddb, query='test_chars', table='ddb_fmts',
+            outfmts={'ndc': '$11.', 'state_cd': '$2.'},
+        )
+        ll = self.sas.submit(
+            "ods listing;\nproc contents data=work.ddb_fmts; run;\nods listing close;\n",
+            results='TEXT'
+        )
+        output = ll['LST']
+        self.assertIn('$11', output)
+        self.assertIn('$2', output)
+
+    def test_duckdb_to_sas_char_lengths(self):
+        """Explicit character lengths honoured."""
+        sd = self.sas.duckdb_to_sas(
+            self.ddb, query='test_chars', table='ddb_clen',
+            char_lengths={'ndc': 11, 'state_cd': 2, 'status': 10},
+        )
+        df = self.sas.sd2df('ddb_clen')
+        df.columns = df.columns.str.lower()
+        # NDC with leading zeros should be preserved
+        ndc_vals = df['ndc'].str.strip()
+        self.assertTrue(ndc_vals.iloc[0].startswith('0'), "NDC leading zeros lost")
+
+    def test_duckdb_to_sas_large_query(self):
+        """Works with a subquery, not just a bare table name."""
+        sd = self.sas.duckdb_to_sas(
+            self.ddb,
+            query="select * from test_large where id <= 500",
+            table='ddb_sub',
+        )
+        self.assertIsInstance(sd, saspy.sasdata.SASdata)
+        ll = self.sas.submit("proc sql noprint; select count(*) into :n from work.ddb_sub; quit;", results='text')
+        n = int(self.sas.symget('n'))
+        self.assertEqual(n, 500)
+
+    def test_duckdb_to_sas_tempkeep(self):
+        """CSV preserved when tempkeep=True, cleaned when False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # tempkeep=True: CSV should remain
+            sd = self.sas.duckdb_to_sas(
+                self.ddb, query='test_chars', table='ddb_tk',
+                tempdir=tmpdir, tempkeep=True,
+            )
+            csv_path = os.path.join(tmpdir, 'ddb_tk.csv')
+            self.assertTrue(os.path.exists(csv_path), "CSV should be kept")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # tempkeep=False (default): CSV should be deleted
+            sd = self.sas.duckdb_to_sas(
+                self.ddb, query='test_chars', table='ddb_rm',
+                tempdir=tmpdir, tempkeep=False,
+            )
+            csv_path = os.path.join(tmpdir, 'ddb_rm.csv')
+            self.assertFalse(os.path.exists(csv_path), "CSV should be removed")
+
+    def test_duckdb_to_sas_empty_query(self):
+        """Empty query returns None with error."""
+        sd = self.sas.duckdb_to_sas(self.ddb, query='', table='ddb_empty')
+        self.assertIsNone(sd)
+
+    def test_duckdb_to_sas_computed_char_lengths(self):
+        """VARCHAR columns without explicit lengths get computed lengths."""
+        sd = self.sas.duckdb_to_sas(
+            self.ddb, query='test_chars', table='ddb_auto',
+        )
+        self.assertIsInstance(sd, saspy.sasdata.SASdata)
+        df = self.sas.sd2df('ddb_auto')
+        df.columns = df.columns.str.lower()
+        # NDC values should be intact (11 chars)
+        ndc_vals = df['ndc'].str.strip()
+        self.assertTrue(all(len(v) == 11 for v in ndc_vals.dropna()))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Uses DuckDB's native COPY TO CSV instead of pandas row-by-row serialization, then submits a generated SAS DATA step with correct length/informat/format/label statements. Many times faster than df2sd for large datasets.

Handles VARCHAR, DATE, TIMESTAMP, BOOLEAN, and numeric types. BOOLEAN cast to INTEGER for SAS compatibility. Char lengths computed via a single DuckDB aggregate query.