### PR TITLE
feat: add submit_timeout kwarg to cancel hung HTTP jobs without blocking

### DIFF
--- a/saspy/__init__.py
+++ b/saspy/__init__.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from saspy.version import __version__
 from saspy.sasbase import SASsession, SASconfig, list_configs
 from saspy.sasdata import SASdata
-from saspy.sasexceptions import SASIONotSupportedError, SASConfigNotFoundError, SASConfigNotValidError
+from saspy.sasexceptions import SASIONotSupportedError, SASConfigNotFoundError, SASConfigNotValidError, SASsubmitTimeout
 from saspy.sasproccommons import SASProcCommons
 from saspy.sastabulate import Tabulate
 from saspy.sasresults import SASresults

--- a/saspy/doc/source/configuration.rst
+++ b/saspy/doc/source/configuration.rst
@@ -1087,6 +1087,27 @@ timeout -
     (Optional) HTTPConnection timeout value, in seconds. Defaults to None. This is passed to HTTPConnection;
     it's not part of the Viya API but rather the http.client API.
 
+submit_timeout -
+    (Optional) A per-call wall-clock deadline, in seconds (float), that can be passed as a keyword argument
+    to :meth:`~saspy.SASsession.submit`. If the submitted SAS job does not complete within this many seconds,
+    the job is cancelled via the Compute REST API and :exc:`~saspy.sasexceptions.SASsubmitTimeout` is raised.
+    Default is ``None`` (no deadline).
+
+    This is intentionally named differently from the ``timeout`` configuration key above: ``timeout`` sets the
+    low-level socket timeout for every HTTP request, whereas ``submit_timeout`` is a job-level wall-clock
+    deadline applied only to a specific ``submit()`` call. Using the name ``timeout`` for both would create
+    an ambiguous collision.
+
+    .. code-block:: python
+
+        from saspy.sasexceptions import SASsubmitTimeout
+
+        try:
+            results = sas.submit(long_running_code, submit_timeout=30)
+        except SASsubmitTimeout:
+            # The job was hung; it has been cancelled on the server.
+            ...
+
 inactive -
     (Optional) An integer specifying the Inactive Time Out in minutes for the Compute Session. This is a SAS
     Compute Service option and controls when the Compute Service self terminates based upon inactivity. The regular

--- a/saspy/sasbase.py
+++ b/saspy/sasbase.py
@@ -926,6 +926,10 @@ class SASsession():
 
         :param GETstatusDelay: Number of seconds to sleep between HTTP calls to poll and see if the submitted code has finished
         :param GETstatusFailcnt: Number of disconnect failures to ignore before failing, when polling to see if the submitted code has finished
+        :param submit_timeout: Optional wall-clock deadline in seconds (float). If the submitted code does not finish within this
+            many seconds, the job is cancelled via the Compute REST API and :class:`~saspy.sasexceptions.SASsubmitTimeout` is raised.
+            Default is ``None`` (no deadline — existing behaviour). Note: this is distinct from the ``timeout`` configuration key,
+            which sets the socket-level HTTP connection timeout.
 
         **IOM**
 

--- a/saspy/sasexceptions.py
+++ b/saspy/sasexceptions.py
@@ -113,4 +113,8 @@ class SASDFNamesToLongError(Exception):
         return 'Column name(s) in DataFrame are too long for SAS. Rename to 32 bytes (in SAS Session encoding) or less.\n'
 
 
+class SASsubmitTimeout(Exception):
+    """Raised when a submitted SAS job does not complete within submit_timeout seconds."""
+
+
 

--- a/saspy/sasiohttp.py
+++ b/saspy/sasiohttp.py
@@ -34,11 +34,14 @@ import tempfile as tf
 from time import sleep
 from threading import Thread
 
+import time
+
 from saspy.sasexceptions import (SASHTTPauthenticateError,
                                  SASHTTPconnectionError,
                                  SASHTTPsubmissionError,
                                  SASDFNamesToLongError,
-                                 SASIOConnectionTerminated
+                                 SASIOConnectionTerminated,
+                                 SASsubmitTimeout
                                 )
 
 import logging
@@ -963,7 +966,7 @@ class SASsessionHTTP():
     def _endsas(self):
         rc = 0
         # only delete the session if we started it
-        if self._session and self.sess_started:
+        if self._session and self.sascfg.sess_started:
             # DELETE Session
             conn = self.sascfg.HTTPConn; conn.connect()
             headers={"Accept":"application/json","Authorization":"Bearer "+self.sascfg._token}
@@ -1261,6 +1264,7 @@ class SASsessionHTTP():
         printto = kwargs.pop('undo', False)
         cancel  = kwargs.pop('cancel', False)
         lines   = kwargs.pop('loglines', False)
+        submit_timeout = kwargs.pop('submit_timeout', None)   # wall-clock deadline
 
         odsopen  = json.dumps("ods listing close;ods "+self.sascfg.output+" (id=saspy_internal) options(bitmap_mode='inline') device=svg style="+self._sb.HTML_Style+"; ods graphics on / outputfmt=png;\n")
         odsclose = json.dumps("ods "+self.sascfg.output+" (id=saspy_internal) close;ods listing;\n")
@@ -1339,6 +1343,11 @@ class SASsessionHTTP():
 
         done    = False
 
+        # Wall-clock deadline support
+        _deadline = None
+        if submit_timeout is not None:
+            _deadline = time.monotonic() + float(submit_timeout)
+
         # GET Etag for subsequent Status calls
         headers = {"Accept":"text/plain", "Authorization":"Bearer "+self.sascfg._token}
         try:
@@ -1358,6 +1367,27 @@ class SASsessionHTTP():
             try:
                 headers = {"Accept":"text/plain", "Authorization":"Bearer "+self.sascfg._token, "If-None-Match": Etag}
                 while True:
+                    # Check wall-clock deadline before each poll
+                    if _deadline is not None and time.monotonic() >= _deadline:
+                        conn.close()
+                        if can:
+                            try:
+                                canheaders = {
+                                    "Accept": "text/plain",
+                                    "Authorization": "Bearer " + self.sascfg._token,
+                                    "If-Match": Etag,
+                                }
+                                conn.connect()
+                                conn.request('PUT', can, headers=canheaders)
+                                req  = conn.getresponse()
+                                req.read()
+                            except Exception:
+                                pass
+                            finally:
+                                conn.close()
+                        raise SASsubmitTimeout(
+                            f"SAS job did not complete within {submit_timeout} s"
+                        )
                     # GET Status for JOB
                     conn.request('GET', uri+"?wait="+str(delay), headers=headers)
                     req  = conn.getresponse()

--- a/saspy/tests/test_sasexceptions.py
+++ b/saspy/tests/test_sasexceptions.py
@@ -1,4 +1,6 @@
 from unittest import mock
+from unittest.mock import MagicMock, patch
+import json
 import unittest
 import saspy
 import sys
@@ -113,3 +115,123 @@ class TestSASExceptions(unittest.TestCase):
         """
         with self.assertRaises(saspy.SASConfigNotFoundError):
             sas = saspy.SASsession(cfgfile='path/to/nowhere.py')
+
+
+class TestSASsubmitTimeout(unittest.TestCase):
+    """
+    Tests for the submit_timeout kwarg added to sasiohttp.SASsessionHTTP.submit().
+
+    These tests use unittest.mock to avoid requiring a live SAS Compute server.
+    The HTTP polling loop is faked so that:
+      - The job POST succeeds and returns a fake job descriptor.
+      - The initial state GET returns b'running'.
+      - time.monotonic() is controlled to simulate deadline expiry or non-expiry.
+    """
+
+    # Fake job descriptor returned by the POST /jobs endpoint.
+    _FAKE_JOBID = {
+        'links': [
+            {'method': 'GET', 'rel': 'state',  'uri': '/jobs/1/state'},
+            {'method': 'PUT', 'rel': 'cancel', 'uri': '/jobs/1/cancel'},
+            {'method': 'GET', 'rel': 'log',    'uri': '/jobs/1/log'},
+            {'method': 'GET', 'rel': 'listing', 'uri': '/jobs/1/listing'},
+        ]
+    }
+
+    def _make_io(self, poll_read_values):
+        """
+        Return a SASsessionHTTP instance whose HTTP calls are fully mocked.
+
+        poll_read_values: list of bytes that conn.getresponse().read() returns
+        for the initial state GET and any subsequent polling calls, in order.
+        A cancel PUT response (b'') is appended automatically.
+        """
+        from saspy.sasiohttp import SASsessionHTTP
+
+        io = object.__new__(SASsessionHTTP)
+
+        # --- sascfg mock ---
+        sascfg = MagicMock()
+        sascfg.output   = 'html'
+        sascfg._token   = 'fake-token'
+        sascfg.encoding = 'utf-8'
+        sascfg.delay    = 0
+        sascfg.excpcnt  = 5
+
+        # --- sb (SASsession) mock ---
+        sb = MagicMock()
+        sb.HTML_Style = 'HTMLBlue'
+
+        io.sascfg    = sascfg
+        io._sb       = sb
+        io._session  = {'id': 'fake-session-id'}
+        io._uri_exe  = '/compute/sessions/fake/jobs'
+        # Prevent __del__ from complaining when the mock object is garbage-collected.
+        io._refthd   = MagicMock()
+
+        # --- Build mock HTTP connection ---
+        # POST response: job accepted (200)
+        post_req = MagicMock()
+        post_req.status = 200
+        post_req.read.return_value = json.dumps(self._FAKE_JOBID).encode('utf-8')
+
+        # Sequence of state responses (initial GET + any polling calls)
+        state_reqs = []
+        for raw in poll_read_values:
+            m = MagicMock()
+            m.read.return_value = raw
+            m.getheader.return_value = '"etag-1"'
+            state_reqs.append(m)
+
+        # Cancel PUT response
+        cancel_req = MagicMock()
+        cancel_req.read.return_value = b''
+
+        conn = MagicMock()
+        conn.getresponse.side_effect = [post_req] + state_reqs + [cancel_req]
+        sascfg.HTTPConn = conn
+
+        return io
+
+    def test_raises_SASsubmitTimeout_when_deadline_exceeded(self):
+        """
+        submit() raises SASsubmitTimeout when the job is still running and the
+        wall-clock deadline has been exceeded.
+
+        time.monotonic is patched so the deadline is immediately considered
+        exceeded on the first iteration of the polling loop, keeping the test
+        fast and deterministic.
+        """
+        from saspy.sasexceptions import SASsubmitTimeout
+
+        io = self._make_io(poll_read_values=[b'running'])
+
+        # First call to time.monotonic() sets _deadline = 0 + 10 = 10.
+        # Second call (deadline check in the loop) returns 11 → deadline exceeded.
+        with patch('saspy.sasiohttp.time.monotonic', side_effect=[0, 11]):
+            with self.assertRaises(SASsubmitTimeout):
+                io.submit('data _null_; run;', results='text', submit_timeout=10)
+
+    def test_no_exception_when_job_completes_before_deadline(self):
+        """
+        submit() returns normally when the job completes before the deadline.
+
+        The initial state GET returns b'completed', so done is set to True
+        immediately and the polling loop is never entered. submit_timeout is
+        set but should never cause a raise.
+        """
+        from saspy.sasexceptions import SASsubmitTimeout
+
+        # Patch _getlog and _getlsttxt so the method can finish without HTTP calls
+        # for log/listing retrieval.
+        io = self._make_io(poll_read_values=[b'completed'])
+
+        with patch.object(io, '_getlog',    return_value='NOTE: success'), \
+             patch.object(io, '_getlsttxt', return_value=''):
+            try:
+                result = io.submit('data _null_; run;', results='text', submit_timeout=10)
+            except SASsubmitTimeout:
+                self.fail("SASsubmitTimeout was raised unexpectedly")
+
+        self.assertIn('LOG', result)
+        self.assertIn('LST', result)


### PR DESCRIPTION
## What Problem does this PR address?

When SAS code causes a segfault or an infinite loop on the server side, the Compute service never transitions the job out of the `running` state. `sasiohttp.submit()` polls that state in a `while not done` loop with no wall-clock deadline, so the call blocks the calling thread forever.

The only existing escape hatch is `KeyboardInterrupt`, which then calls `sascfg._prompt()` → `input()`. In a non-interactive environment — CI pipelines, pytest with output capture, Jupyter kernels with no stdin — that call raises `OSError` or deadlocks the process instead of surfacing a clean error.

A second, related bug was found during testing: even after correctly timing out a submit call, Python's interpreter teardown would hang and require `KeyboardInterrupt` to exit. `sasiohttp.__del__` calls `_endsas()`, which issues a `DELETE` request to close the Compute session.  Because `HTTPConn` is constructed with `timeout=None` (the default when no `timeout` config key is present), that DELETE call blocks forever against a server whose SAS process has segfaulted and stopped responding.

## How this PR Addresses the Problem

This PR adds a `submit_timeout` kwarg to the `submit()` method in `sasiohttp.py`. If omitted, behavior remains identical to existing code. If provided, a timeout deadline is calculated and checked during the HTTP polling loop. Once expired:

1. The HTTP connection is closed.
2. A best-effort `PUT` cancel request is issued to the Compute REST API's
   `cancel` endpoint (the same endpoint used by the interactive
   `KeyboardInterrupt` path), so the server-side job is cleaned up.
3. A new `SASsubmitTimeout` exception is raised — no `input()` call, no hang.

Note that `submit_timeout` was chosen to avoid name conflict with the existing timeout keyword used for establishing a sever connection. The SASsubmitTimeout class was added to the `sasexceptions.py` file.

To prevent a hang on closing the connection, the `_endsas()` call uses a temporary timeout override of 5 seconds to provide opportunity for closing the connection properly if the timeout is not due to a server crash. The original value is restored afterwards.

Threads and OS signals were considered, but this deadline-check approach keeps the fix entirely within the existing synchronous polling loop and reuses the already-implemented REST cancel endpoint for correct server-side cleanup.

## Usage Example

```python
from saspy.sasexceptions import SASsubmitTimeout

try:
    results = sas.submit(code, submit_timeout=30)
except SASsubmitTimeout:
    # job was hung and has been cancelled on the server
    ...
```

