### PR TITLE
Fix typo in appserver variable name

### DIFF
--- a/saspy/sasioiom.py
+++ b/saspy/sasioiom.py
@@ -228,7 +228,7 @@ class SASconfigIOM:
 
         inapp = kwargs.get('appserver', '')
         if len(inapp) > 0:
-            if lock and len(self.apserver):
+            if lock and len(self.appserver):
                 logger.warning("Parameter 'appserver' passed to SAS_session was ignored due to configuration restriction.")
             else:
                 self.appserver = inapp


### PR DESCRIPTION
### Description
Fixes a typo in SASconfigIOM.__init__ in sasioiom.py where self.apserver referenced instead of self.appserver

### Error
Passing appserver at runtime raises:
`AttributeError: 'SASconfigIOM' object has no attribute 'apserver'`